### PR TITLE
Updating default grafana.ini to server things on subpath /grafana. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Perform the following steps every time you bring up a fresh instance of the VM:
 ```
 vagrant up
 ```
-2. You are now ready to configure your data source via the Grafana web interface.  Go to http://10.3.3.3:3000/admin in your browser (10.3.3.3 is the statically set private address of your local VM)
+2. You are now ready to configure your data source via the Grafana web interface.  Go to http://10.3.3.3:3000/grafana/admin in your browser (10.3.3.3 is the statically set private address of your local VM)
 3. Login with the default username `admin` and password `admin`
 4. Change the password or hit "skip" if prompted to change password
 5. Click on "Data Sources" in the Configuration menu on the left hand side
@@ -42,7 +42,7 @@ vagrant up
 7. Enter the username and password in the `User` and `Password` fields
 8. Click `Save and Test`. It should provide imediate feedback if things are working or not.
 
-Assuming it worked, you can now navigate to the dashboards at http://10.3.3.3:3000/ and see data.
+Assuming it worked, you can now navigate to the dashboards at http://10.3.3.3:3000/grafana and see data.
 
 ## Using the VM
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -53,6 +53,9 @@ Vagrant.configure("2") do |config|
         sed -i 's/^;default_theme.*/default_theme = light/' /etc/grafana/grafana.ini
         #need the following setting so the google analytics script tags are not shown
         sed -i 's/^;disable_sanitize_html.*/disable_sanitize_html = true/' /etc/grafana/grafana.ini
+        #server from /grafana subpath to match prod and dev instances behind a proxy
+        sed -i 's/^;root_url.*/root_url = %(protocol)s:\/\/%(domain)s:3000\/grafana/' /etc/grafana/grafana.ini
+        sed -i 's/^;serve_from_sub_path.*/serve_from_sub_path = true/' /etc/grafana/grafana.ini
         
         ### Start plugin installs ###
         cd /vagrant/plugins


### PR DESCRIPTION
The branch name is kinda terrible for this given how it got implemented without a proxy, but updated grafana.ini to serve up the page on /grafana subpath. This seemed the simplest approach with least likelihood of breaking things since node need to install apache. 