### PR TITLE
Use unique count instead of count to calculate Total Flows

### DIFF
--- a/dashboards/flow-analysis.json
+++ b/dashboards/flow-analysis.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1581641598231,
+  "iteration": 1581712552803,
   "links": [],
   "panels": [
     {
@@ -270,7 +270,7 @@
         "show": true
       },
       "links": [],
-      "max_total": 85998846,
+      "max_total": 83161319,
       "option_1": "netsage",
       "option_2": "maheshtest",
       "option_3": "plugin",
@@ -278,11 +278,11 @@
       "options": {},
       "parsed_data": [
         {
-          "avg": 508868.91124260356,
+          "avg": 492078.81065088755,
           "label": "Count",
-          "max": 2577118,
-          "min": 5553,
-          "total": 85998846
+          "max": 2600869,
+          "min": 3523,
+          "total": 83161319
         }
       ],
       "rgb_values": [
@@ -1133,7 +1133,7 @@
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
           "decimals": 1,
           "mappingType": 1,
-          "pattern": "Count",
+          "pattern": "Unique Count",
           "thresholds": [],
           "type": "number",
           "unit": "short"
@@ -1180,9 +1180,11 @@
               "type": "max"
             },
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "5",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "meta.sensor_id.keyword:$sensors AND -$src_scope:\"\"",
@@ -1405,7 +1407,7 @@
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
           "decimals": 1,
           "mappingType": 1,
-          "pattern": "Count",
+          "pattern": "Unique Count",
           "thresholds": [],
           "type": "number",
           "unit": "short"
@@ -1442,9 +1444,11 @@
               "type": "avg"
             },
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "4",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "meta.sensor_id.keyword:$sensors AND -$src_scope:\"\"",
@@ -1706,7 +1710,7 @@
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
           "decimals": 1,
           "mappingType": 1,
-          "pattern": "Count",
+          "pattern": "Unique Count",
           "thresholds": [],
           "type": "number",
           "unit": "short"
@@ -1753,9 +1757,11 @@
               "type": "max"
             },
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "5",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "meta.sensor_id.keyword:$sensors AND -$dst_scope:\"\"",
@@ -1978,7 +1984,7 @@
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
           "decimals": 1,
           "mappingType": 1,
-          "pattern": "Count",
+          "pattern": "Unique Count",
           "thresholds": [],
           "type": "number",
           "unit": "short"
@@ -2015,9 +2021,11 @@
               "type": "avg"
             },
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "4",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "meta.sensor_id.keyword:$sensors AND -$dst_scope:\"\"",
@@ -2698,11 +2706,11 @@
             "rgba(50, 172, 45, 0.97)"
           ],
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "decimals": null,
-          "pattern": "Count",
+          "decimals": 1,
+          "pattern": "Unique Count",
           "thresholds": [],
           "type": "number",
-          "unit": "locale"
+          "unit": "short"
         },
         {
           "alias": "Total Volume",
@@ -2814,9 +2822,11 @@
               "type": "max"
             },
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "7",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "meta.sensor_id.keyword:$sensors",

--- a/dashboards/flow-analysis.json
+++ b/dashboards/flow-analysis.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1581014502251,
+  "iteration": 1581641598231,
   "links": [],
   "panels": [
     {
@@ -270,7 +270,7 @@
         "show": true
       },
       "links": [],
-      "max_total": 77040787,
+      "max_total": 85998846,
       "option_1": "netsage",
       "option_2": "maheshtest",
       "option_3": "plugin",
@@ -278,11 +278,11 @@
       "options": {},
       "parsed_data": [
         {
-          "avg": 455862.6449704142,
+          "avg": 508868.91124260356,
           "label": "Count",
-          "max": 2632634,
-          "min": 0,
-          "total": 77040787
+          "max": 2577118,
+          "min": 5553,
+          "total": 85998846
         }
       ],
       "rgb_values": [
@@ -2248,9 +2248,11 @@
           ],
           "metrics": [
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "1",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "meta.sensor_id.keyword:$sensors",

--- a/dashboards/flow-analysis.json
+++ b/dashboards/flow-analysis.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1581712552803,
+  "iteration": 1582056841480,
   "links": [],
   "panels": [
     {
@@ -32,8 +32,7 @@
         "What are the bandwidth patterns in the network?",
         "What are the patterns of loss in the network?",
         "What are the patterns of latency in the network?",
-        "What are the current flow data summary statistics?",
-        "Advanced Flow Analysis"
+        "What are the current flow data summary statistics?"
       ],
       "array_option_2": [
         "/grafana/d/000000003/bandwidth-dashboard",
@@ -47,8 +46,7 @@
         "/grafana/d/000000004/bandwidth-patterns",
         "/grafana/d/000000006/loss-patterns",
         "/grafana/d/000000005/latency-patterns",
-        "/grafana/d/CJC1FFhmz/other-flow-stats",
-        "/grafana/d/VuuXrnPWz/flow-analysis"
+        "/grafana/d/CJC1FFhmz/other-flow-stats"
       ],
       "array_option_3": [
         "",
@@ -272,7 +270,7 @@
         "show": true
       },
       "links": [],
-      "max_total": 83161319,
+      "max_total": 61355245,
       "option_1": "netsage",
       "option_2": "maheshtest",
       "option_3": "plugin",
@@ -280,11 +278,11 @@
       "options": {},
       "parsed_data": [
         {
-          "avg": 492078.81065088755,
+          "avg": 363048.78698224854,
           "label": "Count",
-          "max": 2600869,
-          "min": 3523,
-          "total": 83161319
+          "max": 1839113,
+          "min": 366,
+          "total": 61355245
         }
       ],
       "rgb_values": [
@@ -2337,7 +2335,7 @@
                 "min_doc_count": 1,
                 "order": "desc",
                 "orderBy": "_count",
-                "size": "10"
+                "size": "5"
               },
               "type": "terms"
             },
@@ -2354,9 +2352,11 @@
           ],
           "metrics": [
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "1",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "meta.sensor_id.keyword:$sensors",
@@ -2371,7 +2371,7 @@
       "title": "Top Protocols",
       "tooltip": {
         "shared": true,
-        "sort": 0,
+        "sort": 2,
         "value_type": "individual"
       },
       "type": "graph",
@@ -2414,6 +2414,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "netsage",
+      "decimals": 1,
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -2459,7 +2460,7 @@
               "settings": {
                 "min_doc_count": 1,
                 "order": "desc",
-                "orderBy": "_count",
+                "orderBy": "1",
                 "size": "5"
               },
               "type": "terms"
@@ -2477,9 +2478,11 @@
           ],
           "metrics": [
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "1",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "meta.sensor_id.keyword:$sensors",
@@ -2494,7 +2497,7 @@
       "title": "Top Source Ports",
       "tooltip": {
         "shared": true,
-        "sort": 0,
+        "sort": 2,
         "value_type": "individual"
       },
       "type": "graph",
@@ -2536,6 +2539,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
+      "decimals": 1,
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -2546,13 +2550,14 @@
       },
       "id": 37,
       "legend": {
+        "alignAsTable": true,
         "avg": false,
         "current": false,
-        "max": false,
+        "max": true,
         "min": false,
         "show": false,
-        "total": false,
-        "values": false
+        "total": true,
+        "values": true
       },
       "lines": false,
       "linewidth": 1,
@@ -2579,7 +2584,7 @@
               "settings": {
                 "min_doc_count": 1,
                 "order": "desc",
-                "orderBy": "_count",
+                "orderBy": "1",
                 "size": "5"
               },
               "type": "terms"
@@ -2597,9 +2602,11 @@
           ],
           "metrics": [
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "1",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "meta.sensor_id.keyword:$sensors",
@@ -2613,8 +2620,8 @@
       "timeShift": null,
       "title": "Top Destination Ports",
       "tooltip": {
-        "shared": false,
-        "sort": 0,
+        "shared": true,
+        "sort": 2,
         "value_type": "individual"
       },
       "type": "graph",

--- a/dashboards/flow-analysis.json
+++ b/dashboards/flow-analysis.json
@@ -32,7 +32,8 @@
         "What are the bandwidth patterns in the network?",
         "What are the patterns of loss in the network?",
         "What are the patterns of latency in the network?",
-        "What are the current flow data summary statistics?"
+        "What are the current flow data summary statistics?",
+        "Advanced Flow Analysis"
       ],
       "array_option_2": [
         "/grafana/d/000000003/bandwidth-dashboard",
@@ -46,7 +47,8 @@
         "/grafana/d/000000004/bandwidth-patterns",
         "/grafana/d/000000006/loss-patterns",
         "/grafana/d/000000005/latency-patterns",
-        "/grafana/d/CJC1FFhmz/other-flow-stats"
+        "/grafana/d/CJC1FFhmz/other-flow-stats",
+        "/grafana/d/VuuXrnPWz/flow-analysis"
       ],
       "array_option_3": [
         "",

--- a/dashboards/flow-data-for-circuits.json
+++ b/dashboards/flow-data-for-circuits.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1581576722096,
+  "iteration": 1581713304075,
   "links": [],
   "panels": [
     {
@@ -270,7 +270,7 @@
         "show": true
       },
       "links": [],
-      "max_total": 61068977,
+      "max_total": 83088573,
       "option_1": "netsage",
       "option_2": "maheshtest",
       "option_3": "plugin",
@@ -278,11 +278,11 @@
       "options": {},
       "parsed_data": [
         {
-          "avg": 361354.89349112427,
+          "avg": 246553.6290801187,
           "label": "Count",
-          "max": 2786014,
-          "min": 699,
-          "total": 61068977
+          "max": 1745891,
+          "min": 11,
+          "total": 83088573
         }
       ],
       "rgb_values": [
@@ -456,7 +456,7 @@
           ],
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
           "decimals": 1,
-          "pattern": "Count",
+          "pattern": "Unique Count",
           "thresholds": [],
           "type": "number",
           "unit": "short"
@@ -579,9 +579,11 @@
               "type": "max"
             },
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "7",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "meta.sensor_id.keyword:$Sensors AND -$source_scope:\"\" AND -$dest_scope:\"\"",
@@ -775,7 +777,7 @@
           ],
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
           "decimals": 1,
-          "pattern": "Count",
+          "pattern": "Unique Count",
           "thresholds": [],
           "type": "number",
           "unit": "short"
@@ -874,9 +876,11 @@
               "type": "avg"
             },
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "7",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "meta.sensor_id.keyword:$Sensors AND -$source_scope:\"\" AND -$dest_scope:\"\"",
@@ -1074,7 +1078,7 @@
           ],
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
           "decimals": 1,
-          "pattern": "Count",
+          "pattern": "Unique Count",
           "thresholds": [],
           "type": "number",
           "unit": "short"
@@ -1197,9 +1201,11 @@
               "type": "max"
             },
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "7",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "meta.sensor_id.keyword:$Sensors AND -$source_scope:\"\" AND -$dest_scope:\"\"",
@@ -1393,7 +1399,7 @@
           ],
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
           "decimals": 1,
-          "pattern": "Count",
+          "pattern": "Unique Count",
           "thresholds": [],
           "type": "number",
           "unit": "short"
@@ -1492,9 +1498,11 @@
               "type": "avg"
             },
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "7",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "meta.sensor_id.keyword:$Sensors AND -$source_scope:\"\" AND -$dest_scope:\"\"",
@@ -1691,11 +1699,11 @@
             "rgba(50, 172, 45, 0.97)"
           ],
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "decimals": 0,
-          "pattern": "Count",
+          "decimals": 1,
+          "pattern": "Unique Count",
           "thresholds": [],
           "type": "number",
-          "unit": "locale"
+          "unit": "short"
         },
         {
           "alias": "Total Vol.",
@@ -1850,9 +1858,11 @@
               "type": "max"
             },
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "7",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             },
             {
               "field": "values.bits_per_second",
@@ -1867,11 +1877,6 @@
               "meta": {},
               "settings": {},
               "type": "max"
-            },
-            {
-              "field": "select field",
-              "id": "11",
-              "type": "count"
             }
           ],
           "query": "meta.sensor_id.keyword:$Sensors AND -$source_scope:\"\" AND -$dest_scope:\"\"",
@@ -1966,7 +1971,7 @@
     }
   ],
   "refresh": false,
-  "schemaVersion": 18,
+  "schemaVersion": 19,
   "style": "dark",
   "tags": [
     "flow",

--- a/dashboards/flow-data-for-data-archives.json
+++ b/dashboards/flow-data-for-data-archives.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1581577923110,
+  "iteration": 1581714193003,
   "links": [],
   "panels": [
     {
@@ -270,7 +270,7 @@
         "show": true
       },
       "links": [],
-      "max_total": 69103110,
+      "max_total": 82998921,
       "option_1": "netsage",
       "option_2": "maheshtest",
       "option_3": "plugin",
@@ -278,11 +278,11 @@
       "options": {},
       "parsed_data": [
         {
-          "avg": 406488.8823529412,
+          "avg": 491117.875739645,
           "label": "Count",
-          "max": 1195950,
-          "min": 2137,
-          "total": 69103110
+          "max": 2600869,
+          "min": 0,
+          "total": 82998921
         }
       ],
       "rgb_values": [
@@ -456,7 +456,7 @@
           ],
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
           "decimals": 1,
-          "pattern": "Count",
+          "pattern": "Unique Count",
           "thresholds": [],
           "type": "number",
           "unit": "short"
@@ -579,9 +579,11 @@
               "type": "max"
             },
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "7",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "meta.sensor_id.keyword:$dtn_sensors",
@@ -782,7 +784,7 @@
           ],
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
           "decimals": 1,
-          "pattern": "Count",
+          "pattern": "Unique Count",
           "thresholds": [],
           "type": "number",
           "unit": "short"
@@ -881,9 +883,11 @@
               "type": "avg"
             },
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "7",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "meta.sensor_id.keyword:$dtn_sensors",
@@ -1151,7 +1155,7 @@
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
           "decimals": 1,
           "mappingType": 1,
-          "pattern": "Count",
+          "pattern": "Unique Count",
           "thresholds": [],
           "type": "number",
           "unit": "short"
@@ -1282,9 +1286,11 @@
               "type": "sum"
             },
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "11",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "meta.sensor_id.keyword:$dtn_sensors",
@@ -1482,7 +1488,7 @@
           ],
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
           "decimals": 1,
-          "pattern": "Count",
+          "pattern": "Unique Count",
           "thresholds": [],
           "type": "number",
           "unit": "short"
@@ -1605,9 +1611,11 @@
               "type": "max"
             },
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "7",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "meta.sensor_id.keyword:$dtn_sensors",
@@ -1808,7 +1816,7 @@
           ],
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
           "decimals": 1,
-          "pattern": "Count",
+          "pattern": "Unique Count",
           "thresholds": [],
           "type": "number",
           "unit": "short"
@@ -1907,9 +1915,11 @@
               "type": "avg"
             },
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "7",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "meta.sensor_id.keyword:$dtn_sensors",
@@ -2153,7 +2163,7 @@
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
           "decimals": 1,
           "mappingType": 1,
-          "pattern": "Count",
+          "pattern": "Unique Count",
           "thresholds": [],
           "type": "number",
           "unit": "short"
@@ -2268,9 +2278,11 @@
               "type": "sum"
             },
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "13",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "meta.sensor_id.keyword:$dtn_sensors",
@@ -2543,7 +2555,7 @@
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
           "decimals": 1,
           "mappingType": 1,
-          "pattern": "Count",
+          "pattern": "Unique Count",
           "thresholds": [],
           "type": "number",
           "unit": "short"
@@ -2720,9 +2732,11 @@
               "type": "max"
             },
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "27",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             },
             {
               "field": "values.bits_per_second",
@@ -2801,7 +2815,7 @@
     }
   ],
   "refresh": "",
-  "schemaVersion": 18,
+  "schemaVersion": 19,
   "style": "dark",
   "tags": [
     "netsage",

--- a/dashboards/flow-data-per-country.json
+++ b/dashboards/flow-data-per-country.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1581640336609,
+  "iteration": 1581715762965,
   "links": [],
   "panels": [
     {
@@ -271,7 +271,7 @@
         "show": true
       },
       "links": [],
-      "max_total": 86242384,
+      "max_total": 82868321,
       "option_1": "netsage",
       "option_2": "netsagenavigation",
       "option_3": "plugin",
@@ -279,11 +279,11 @@
       "options": {},
       "parsed_data": [
         {
-          "avg": 510309.9644970414,
+          "avg": 490345.0946745562,
           "label": "Count",
-          "max": 2577118,
-          "min": 5553,
-          "total": 86242384
+          "max": 2600869,
+          "min": 3231,
+          "total": 82868321
         }
       ],
       "rgb_values": [
@@ -673,7 +673,7 @@
           ],
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
           "decimals": 1,
-          "pattern": "Count",
+          "pattern": "Unique Count",
           "thresholds": [],
           "type": "number",
           "unit": "short"
@@ -796,9 +796,11 @@
               "type": "max"
             },
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "7",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "meta.src_country_name.keyword:$Country AND meta.sensor_id.keyword:$Sensors AND -meta.dst_country_name.keyword:\"\"",
@@ -992,7 +994,7 @@
           ],
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
           "decimals": 1,
-          "pattern": "Count",
+          "pattern": "Unique Count",
           "thresholds": [],
           "type": "number",
           "unit": "short"
@@ -1091,9 +1093,11 @@
               "type": "avg"
             },
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "7",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "meta.src_country_name.keyword:$Country AND meta.sensor_id.keyword:$Sensors AND -meta.dst_country_name.keyword:\"\"",
@@ -1505,7 +1509,7 @@
           ],
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
           "decimals": 1,
-          "pattern": "Count",
+          "pattern": "Unique Count",
           "thresholds": [],
           "type": "number",
           "unit": "short"
@@ -1628,9 +1632,11 @@
               "type": "max"
             },
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "7",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "meta.dst_country_name.keyword:$Country AND meta.sensor_id.keyword:$Sensors AND -meta.src_country_name.keyword:\"\"",
@@ -1824,7 +1830,7 @@
           ],
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
           "decimals": 1,
-          "pattern": "Count",
+          "pattern": "Unique Count",
           "thresholds": [],
           "type": "number",
           "unit": "short"
@@ -1923,9 +1929,11 @@
               "type": "avg"
             },
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "7",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "meta.dst_country_name.keyword:$Country AND meta.sensor_id.keyword:$Sensors AND -meta.src_country_name.keyword:\"\"",
@@ -2181,12 +2189,12 @@
             "rgba(50, 172, 45, 0.97)"
           ],
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "decimals": 0,
+          "decimals": 1,
           "mappingType": 1,
-          "pattern": "Count",
+          "pattern": "Unique Count",
           "thresholds": [],
           "type": "number",
-          "unit": "locale"
+          "unit": "short"
         },
         {
           "alias": "Avg Rate",
@@ -2290,11 +2298,11 @@
               "type": "max"
             },
             {
-              "field": "values.bits_per_second",
+              "field": "meta.id.keyword",
               "id": "6",
               "meta": {},
               "settings": {},
-              "type": "count"
+              "type": "cardinality"
             },
             {
               "field": "values.bits_per_second",
@@ -2733,52 +2741,52 @@
         [
           "United States",
           "United States",
-          3463401.902733906
+          3424422.187561155
         ],
         [
           "Brazil",
           "United States",
-          1171792.463782274
+          1262533.83719517
         ],
         [
           "United Kingdom",
           "United States",
-          384722.63477813
+          357623.642715532
         ],
         [
           "Puerto Rico",
           "United States",
-          99771.726349896
+          103277.044535184
         ],
         [
           "Germany",
           "United States",
-          74905.958246339
+          72209.245400332
         ],
         [
           "Switzerland",
           "United States",
-          71936.393623808
+          69421.467738693
         ],
         [
           "Spain",
           "United States",
-          60447.170065809994
+          55025.151152018
         ],
         [
           "France",
           "United States",
-          38220.734990506004
+          39015.388077147
         ],
         [
           "Italy",
           "United States",
-          28973.593876115
+          26974.992715587
         ],
         [
           "Ireland",
           "United States",
-          14927.622940288
+          14981.506649216
         ]
       ],
       "table_data_type": "Sum",
@@ -4156,52 +4164,52 @@
         [
           "United States",
           "United States",
-          3463401.902733906
+          3424422.187561155
         ],
         [
           "United States",
           "Brazil",
-          418099.311745528
+          387865.16459819
         ],
         [
           "United States",
           "Puerto Rico",
-          382226.897879104
+          387010.50213448
         ],
         [
           "United States",
           "United Kingdom",
-          185236.758487298
+          200098.791619744
         ],
         [
           "United States",
           "Germany",
-          99422.732356204
+          104242.091230285
         ],
         [
           "United States",
           "U.S. Virgin Islands",
-          47378.601926656
+          45670.685908992
         ],
         [
           "United States",
           "Estonia",
-          25738.461045184
+          33916.545522624
         ],
         [
           "United States",
           "Belgium",
-          24864.047867585
+          26617.058186389
         ],
         [
           "United States",
           "Hong Kong",
-          16618.63487551
+          16651.102767059
         ],
         [
           "United States",
-          "Chile",
-          15543.96502277
+          "Switzerland",
+          15336.990424295
         ]
       ],
       "table_data_type": "Sum",
@@ -5729,11 +5737,11 @@
             "rgba(50, 172, 45, 0.97)"
           ],
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "decimals": 0,
-          "pattern": "Count",
+          "decimals": 1,
+          "pattern": "Unique Count",
           "thresholds": [],
           "type": "number",
-          "unit": "locale"
+          "unit": "short"
         },
         {
           "alias": "Total Volume",
@@ -5845,9 +5853,11 @@
               "type": "max"
             },
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "7",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "(meta.src_country_name.keyword:$Country OR meta.dst_country_name.keyword:$Country) AND meta.sensor_id.keyword:$Sensors",

--- a/dashboards/flow-data-per-country.json
+++ b/dashboards/flow-data-per-country.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1581607989720,
+  "iteration": 1581640336609,
   "links": [],
   "panels": [
     {
@@ -271,7 +271,7 @@
         "show": true
       },
       "links": [],
-      "max_total": 60940957,
+      "max_total": 86242384,
       "option_1": "netsage",
       "option_2": "netsagenavigation",
       "option_3": "plugin",
@@ -279,11 +279,11 @@
       "options": {},
       "parsed_data": [
         {
-          "avg": 716952.4352941177,
+          "avg": 510309.9644970414,
           "label": "Count",
-          "max": 3303995,
-          "min": 1064,
-          "total": 60940957
+          "max": 2577118,
+          "min": 5553,
+          "total": 86242384
         }
       ],
       "rgb_values": [
@@ -496,7 +496,7 @@
               "id": "1",
               "meta": {},
               "settings": {},
-              "type": "count"
+              "type": "cardinality"
             }
           ],
           "query": "meta.src_country_name.keyword:$Country AND meta.sensor_id.keyword:$Sensors AND -meta.dst_country_name.keyword:\"\"",
@@ -1328,7 +1328,7 @@
               "id": "1",
               "meta": {},
               "settings": {},
-              "type": "count"
+              "type": "cardinality"
             }
           ],
           "query": "meta.dst_country_name.keyword:$Country AND meta.sensor_id.keyword:$Sensors AND -meta.src_country_name.keyword:\"\"",
@@ -2413,9 +2413,11 @@
           ],
           "metrics": [
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "1",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "(meta.src_country_name.keyword:$Country OR meta.dst_country_name.keyword:$Country) AND meta.sensor_id.keyword:$Sensors",
@@ -2731,52 +2733,52 @@
         [
           "United States",
           "United States",
-          1891283.886189081
+          3463401.902733906
         ],
         [
           "Brazil",
           "United States",
-          571705.2649062941
+          1171792.463782274
         ],
         [
           "United Kingdom",
           "United States",
-          261675.69281910302
-        ],
-        [
-          "Spain",
-          "United States",
-          139793.503093649
-        ],
-        [
-          "Germany",
-          "United States",
-          133508.57886225
+          384722.63477813
         ],
         [
           "Puerto Rico",
           "United States",
-          50741.250714204
+          99771.726349896
+        ],
+        [
+          "Germany",
+          "United States",
+          74905.958246339
         ],
         [
           "Switzerland",
           "United States",
-          41342.913191493
+          71936.393623808
         ],
         [
-          "Netherlands",
+          "Spain",
           "United States",
-          40834.94758477
+          60447.170065809994
+        ],
+        [
+          "France",
+          "United States",
+          38220.734990506004
         ],
         [
           "Italy",
           "United States",
-          31061.980749592003
+          28973.593876115
         ],
         [
-          "Japan",
+          "Ireland",
           "United States",
-          18148.945183045
+          14927.622940288
         ]
       ],
       "table_data_type": "Sum",
@@ -4154,52 +4156,52 @@
         [
           "United States",
           "United States",
-          2341993.166053675
+          3463401.902733906
         ],
         [
           "United States",
           "Brazil",
-          746328.2857536089
-        ],
-        [
-          "United States",
-          "United Kingdom",
-          248932.66686517
+          418099.311745528
         ],
         [
           "United States",
           "Puerto Rico",
-          200967.644888593
+          382226.897879104
+        ],
+        [
+          "United States",
+          "United Kingdom",
+          185236.758487298
         ],
         [
           "United States",
           "Germany",
-          82732.66604293
-        ],
-        [
-          "United States",
-          "South Korea",
-          73011.863409059
-        ],
-        [
-          "United States",
-          "Netherlands",
-          63875.656530102
-        ],
-        [
-          "United States",
-          "Canada",
-          45723.276427779
+          99422.732356204
         ],
         [
           "United States",
           "U.S. Virgin Islands",
-          37181.566255104
+          47378.601926656
         ],
         [
           "United States",
-          "Australia",
-          31003.888587221
+          "Estonia",
+          25738.461045184
+        ],
+        [
+          "United States",
+          "Belgium",
+          24864.047867585
+        ],
+        [
+          "United States",
+          "Hong Kong",
+          16618.63487551
+        ],
+        [
+          "United States",
+          "Chile",
+          15543.96502277
         ]
       ],
       "table_data_type": "Sum",

--- a/dashboards/flow-data-per-country.json
+++ b/dashboards/flow-data-per-country.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1581715762965,
+  "iteration": 1582055646510,
   "links": [],
   "panels": [
     {
@@ -32,8 +32,7 @@
         "What are the bandwidth patterns in the network?",
         "What are the patterns of loss in the network?",
         "What are the patterns of latency in the network?",
-        "What are the current flow data summary statistics?",
-        "Advanced Flow Analysis"
+        "What are the current flow data summary statistics?"
       ],
       "array_option_2": [
         "/grafana/d/000000003/bandwidth-dashboard",
@@ -47,8 +46,7 @@
         "/grafana/d/000000004/bandwidth-patterns",
         "/grafana/d/000000006/loss-patterns",
         "/grafana/d/000000005/latency-patterns",
-        "/grafana/d/CJC1FFhmz/other-flow-stats",
-        "/grafana/d/VuuXrnPWz/flow-analysis"
+        "/grafana/d/CJC1FFhmz/other-flow-stats"
       ],
       "array_option_3": [
         "",
@@ -273,7 +271,7 @@
         "show": true
       },
       "links": [],
-      "max_total": 82868321,
+      "max_total": 61530525,
       "option_1": "netsage",
       "option_2": "netsagenavigation",
       "option_3": "plugin",
@@ -281,11 +279,11 @@
       "options": {},
       "parsed_data": [
         {
-          "avg": 490345.0946745562,
+          "avg": 364085.94674556213,
           "label": "Count",
-          "max": 2600869,
-          "min": 3231,
-          "total": 82868321
+          "max": 1839113,
+          "min": 366,
+          "total": 61530525
         }
       ],
       "rgb_values": [
@@ -2743,52 +2741,52 @@
         [
           "United States",
           "United States",
-          3424422.187561155
+          3109577.136389556
         ],
         [
           "Brazil",
           "United States",
-          1262533.83719517
+          1135714.729841951
         ],
         [
           "United Kingdom",
           "United States",
-          357623.642715532
+          369216.241343265
         ],
         [
           "Puerto Rico",
           "United States",
-          103277.044535184
-        ],
-        [
-          "Germany",
-          "United States",
-          72209.245400332
+          73707.379971724
         ],
         [
           "Switzerland",
           "United States",
-          69421.467738693
+          69796.032086287
         ],
         [
-          "Spain",
+          "Germany",
           "United States",
-          55025.151152018
+          53394.095755418
         ],
         [
           "France",
           "United States",
-          39015.388077147
-        ],
-        [
-          "Italy",
-          "United States",
-          26974.992715587
+          22400.11884186
         ],
         [
           "Ireland",
           "United States",
-          14981.506649216
+          15041.2438912
+        ],
+        [
+          "Norway",
+          "United States",
+          14735.431368192
+        ],
+        [
+          "Belgium",
+          "United States",
+          13407.918691568
         ]
       ],
       "table_data_type": "Sum",
@@ -4166,52 +4164,52 @@
         [
           "United States",
           "United States",
-          3424422.187561155
+          3109577.136389556
         ],
         [
           "United States",
           "Brazil",
-          387865.16459819
+          318008.945461937
         ],
         [
           "United States",
           "Puerto Rico",
-          387010.50213448
+          264743.018034504
         ],
         [
           "United States",
           "United Kingdom",
-          200098.791619744
+          217540.512866658
         ],
         [
           "United States",
           "Germany",
-          104242.091230285
-        ],
-        [
-          "United States",
-          "U.S. Virgin Islands",
-          45670.685908992
+          106903.69582549299
         ],
         [
           "United States",
           "Estonia",
-          33916.545522624
+          44621.080361984
+        ],
+        [
+          "United States",
+          "U.S. Virgin Islands",
+          41352.00514048
         ],
         [
           "United States",
           "Belgium",
-          26617.058186389
+          37168.576097672994
         ],
         [
           "United States",
-          "Hong Kong",
-          16651.102767059
+          "Netherlands",
+          34230.335259227
         ],
         [
           "United States",
-          "Switzerland",
-          15336.990424295
+          "China",
+          20718.758793553
         ]
       ],
       "table_data_type": "Sum",
@@ -5363,8 +5361,8 @@
               "settings": {
                 "min_doc_count": 1,
                 "order": "desc",
-                "orderBy": "_count",
-                "size": "10"
+                "orderBy": "1",
+                "size": "5"
               },
               "type": "terms"
             },
@@ -5381,9 +5379,13 @@
           ],
           "metrics": [
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "1",
-              "type": "count"
+              "meta": {},
+              "settings": {
+                "precision_threshold": null
+              },
+              "type": "cardinality"
             }
           ],
           "query": "(meta.src_country_name.keyword:$Country OR meta.dst_country_name.keyword:$Country) AND meta.sensor_id.keyword:$Sensors",
@@ -5487,7 +5489,7 @@
               "settings": {
                 "min_doc_count": 1,
                 "order": "desc",
-                "orderBy": "_count",
+                "orderBy": "1",
                 "size": "5"
               },
               "type": "terms"
@@ -5505,9 +5507,11 @@
           ],
           "metrics": [
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "1",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "(meta.src_country_name.keyword:$Country OR meta.dst_country_name.keyword:$Country) AND meta.sensor_id.keyword:$Sensors",
@@ -5610,7 +5614,7 @@
               "settings": {
                 "min_doc_count": 1,
                 "order": "desc",
-                "orderBy": "_count",
+                "orderBy": "1",
                 "size": "5"
               },
               "type": "terms"
@@ -5628,9 +5632,11 @@
           ],
           "metrics": [
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "1",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "(meta.src_country_name.keyword:$Country OR meta.dst_country_name.keyword:$Country) AND meta.sensor_id.keyword:$Sensors",

--- a/dashboards/flow-data-per-country.json
+++ b/dashboards/flow-data-per-country.json
@@ -32,7 +32,8 @@
         "What are the bandwidth patterns in the network?",
         "What are the patterns of loss in the network?",
         "What are the patterns of latency in the network?",
-        "What are the current flow data summary statistics?"
+        "What are the current flow data summary statistics?",
+        "Advanced Flow Analysis"
       ],
       "array_option_2": [
         "/grafana/d/000000003/bandwidth-dashboard",
@@ -46,7 +47,8 @@
         "/grafana/d/000000004/bandwidth-patterns",
         "/grafana/d/000000006/loss-patterns",
         "/grafana/d/000000005/latency-patterns",
-        "/grafana/d/CJC1FFhmz/other-flow-stats"
+        "/grafana/d/CJC1FFhmz/other-flow-stats",
+        "/grafana/d/VuuXrnPWz/flow-analysis"
       ],
       "array_option_3": [
         "",

--- a/dashboards/flow-data-per-organization.json
+++ b/dashboards/flow-data-per-organization.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1581714766077,
+  "iteration": 1582055049569,
   "links": [],
   "panels": [
     {
@@ -32,8 +32,7 @@
         "What are the bandwidth patterns in the network?",
         "What are the patterns of loss in the network?",
         "What are the patterns of latency in the network?",
-        "What are the current flow data summary statistics?",
-        "Advanced Flow Analysis"
+        "What are the current flow data summary statistics?"
       ],
       "array_option_2": [
         "/grafana/d/000000003/bandwidth-dashboard",
@@ -47,8 +46,7 @@
         "/grafana/d/000000004/bandwidth-patterns",
         "/grafana/d/000000006/loss-patterns",
         "/grafana/d/000000005/latency-patterns",
-        "/grafana/d/CJC1FFhmz/other-flow-stats",
-        "/grafana/d/VuuXrnPWz/flow-analysis"
+        "/grafana/d/CJC1FFhmz/other-flow-stats"
       ],
       "array_option_3": [
         "",
@@ -272,7 +270,7 @@
         "show": true
       },
       "links": [],
-      "max_total": 82953761,
+      "max_total": 61634267,
       "option_1": "netsage",
       "option_2": "maheshtest",
       "option_3": "plugin",
@@ -280,11 +278,11 @@
       "options": {},
       "parsed_data": [
         {
-          "avg": 490850.65680473374,
+          "avg": 364699.8047337278,
           "label": "Count",
-          "max": 2600869,
-          "min": 212,
-          "total": 82953761
+          "max": 1839113,
+          "min": 366,
+          "total": 61634267
         }
       ],
       "rgb_values": [
@@ -2187,8 +2185,8 @@
               "settings": {
                 "min_doc_count": 1,
                 "order": "desc",
-                "orderBy": "_count",
-                "size": "10"
+                "orderBy": "1",
+                "size": "5"
               },
               "type": "terms"
             },
@@ -2205,9 +2203,11 @@
           ],
           "metrics": [
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "1",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "(meta.src_organization.keyword:$Organization OR meta.dst_organization.keyword:$Organization) AND meta.sensor_id.keyword:$Sensors",
@@ -2265,6 +2265,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "netsage",
+      "decimals": 1,
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -2310,7 +2311,7 @@
               "settings": {
                 "min_doc_count": 1,
                 "order": "desc",
-                "orderBy": "_count",
+                "orderBy": "1",
                 "size": "5"
               },
               "type": "terms"
@@ -2328,9 +2329,11 @@
           ],
           "metrics": [
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "1",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "(meta.src_organization.keyword:$Organization OR meta.dst_organization.keyword:$Organization) AND meta.sensor_id.keyword:$Sensors",
@@ -2387,6 +2390,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "netsage",
+      "decimals": 1,
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -2432,7 +2436,7 @@
               "settings": {
                 "min_doc_count": 1,
                 "order": "desc",
-                "orderBy": "_count",
+                "orderBy": "1",
                 "size": "5"
               },
               "type": "terms"
@@ -2450,9 +2454,11 @@
           ],
           "metrics": [
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "1",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "(meta.src_organization.keyword:$Organization OR meta.dst_organization.keyword:$Organization) AND meta.sensor_id.keyword:$Sensors",

--- a/dashboards/flow-data-per-organization.json
+++ b/dashboards/flow-data-per-organization.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1581607533497,
+  "iteration": 1581642229522,
   "links": [],
   "panels": [
     {
@@ -270,7 +270,7 @@
         "show": true
       },
       "links": [],
-      "max_total": 88532400,
+      "max_total": 85977503,
       "option_1": "netsage",
       "option_2": "maheshtest",
       "option_3": "plugin",
@@ -278,11 +278,11 @@
       "options": {},
       "parsed_data": [
         {
-          "avg": 523860.3550295858,
+          "avg": 508742.62130177516,
           "label": "Count",
           "max": 2577118,
           "min": 0,
-          "total": 88532400
+          "total": 85977503
         }
       ],
       "rgb_values": [
@@ -495,7 +495,7 @@
               "id": "1",
               "meta": {},
               "settings": {},
-              "type": "count"
+              "type": "cardinality"
             }
           ],
           "query": "meta.src_organization.keyword:$Organization AND meta.sensor_id.keyword:$Sensors -meta.dst_organization.keyword:\"\"",
@@ -1314,7 +1314,7 @@
               "id": "1",
               "meta": {},
               "settings": {},
-              "type": "count"
+              "type": "cardinality"
             }
           ],
           "query": "meta.dst_organization.keyword:$Organization AND meta.sensor_id.keyword:$Sensors -meta.src_organization.keyword:\"\"",
@@ -2099,9 +2099,11 @@
           ],
           "metrics": [
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "1",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "(meta.src_organization.keyword:$Organization OR meta.dst_organization.keyword:$Organization) AND meta.sensor_id.keyword:$Sensors",

--- a/dashboards/flow-data-per-organization.json
+++ b/dashboards/flow-data-per-organization.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1581642229522,
+  "iteration": 1581714766077,
   "links": [],
   "panels": [
     {
@@ -270,7 +270,7 @@
         "show": true
       },
       "links": [],
-      "max_total": 85977503,
+      "max_total": 82953761,
       "option_1": "netsage",
       "option_2": "maheshtest",
       "option_3": "plugin",
@@ -278,11 +278,11 @@
       "options": {},
       "parsed_data": [
         {
-          "avg": 508742.62130177516,
+          "avg": 490850.65680473374,
           "label": "Count",
-          "max": 2577118,
-          "min": 0,
-          "total": 85977503
+          "max": 2600869,
+          "min": 212,
+          "total": 82953761
         }
       ],
       "rgb_values": [
@@ -672,7 +672,7 @@
           ],
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
           "decimals": 1,
-          "pattern": "Count",
+          "pattern": "Unique Count",
           "thresholds": [],
           "type": "number",
           "unit": "short"
@@ -780,9 +780,11 @@
               "type": "max"
             },
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "7",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "meta.src_organization.keyword:$Organization AND meta.sensor_id.keyword:$Sensors -meta.dst_organization.keyword:\"\"",
@@ -976,7 +978,7 @@
           ],
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
           "decimals": 1,
-          "pattern": "Count",
+          "pattern": "Unique Count",
           "thresholds": [],
           "type": "number",
           "unit": "short"
@@ -1075,9 +1077,11 @@
               "type": "avg"
             },
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "7",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "meta.src_organization.keyword:$Organization AND meta.sensor_id.keyword:$Sensors -meta.dst_organization.keyword:\"\"",
@@ -1491,7 +1495,7 @@
           ],
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
           "decimals": 1,
-          "pattern": "Count",
+          "pattern": "Unique Count",
           "thresholds": [],
           "type": "number",
           "unit": "short"
@@ -1584,9 +1588,11 @@
               "type": "max"
             },
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "7",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "meta.dst_organization.keyword:$Organization AND meta.sensor_id.keyword:$Sensors -meta.src_organization.keyword:\"\"",
@@ -1780,7 +1786,7 @@
           ],
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
           "decimals": 1,
-          "pattern": "Count",
+          "pattern": "Unique Count",
           "thresholds": [],
           "type": "number",
           "unit": "short"
@@ -1865,9 +1871,11 @@
               "type": "avg"
             },
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "7",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "meta.dst_organization.keyword:$Organization AND meta.sensor_id.keyword:$Sensors -meta.src_organization.keyword:\"\"",
@@ -2551,11 +2559,11 @@
             "rgba(50, 172, 45, 0.97)"
           ],
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "decimals": null,
-          "pattern": "Count",
+          "decimals": 1,
+          "pattern": "Unique Count",
           "thresholds": [],
           "type": "number",
-          "unit": "locale"
+          "unit": "short"
         },
         {
           "alias": "Total Volume",
@@ -2667,9 +2675,11 @@
               "type": "max"
             },
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "7",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "(meta.src_organization.keyword:$Organization OR meta.dst_organization.keyword:$Organization) AND meta.sensor_id.keyword:$Sensors",

--- a/dashboards/flow-data-per-organization.json
+++ b/dashboards/flow-data-per-organization.json
@@ -32,7 +32,8 @@
         "What are the bandwidth patterns in the network?",
         "What are the patterns of loss in the network?",
         "What are the patterns of latency in the network?",
-        "What are the current flow data summary statistics?"
+        "What are the current flow data summary statistics?",
+        "Advanced Flow Analysis"
       ],
       "array_option_2": [
         "/grafana/d/000000003/bandwidth-dashboard",
@@ -46,7 +47,8 @@
         "/grafana/d/000000004/bandwidth-patterns",
         "/grafana/d/000000006/loss-patterns",
         "/grafana/d/000000005/latency-patterns",
-        "/grafana/d/CJC1FFhmz/other-flow-stats"
+        "/grafana/d/CJC1FFhmz/other-flow-stats",
+        "/grafana/d/VuuXrnPWz/flow-analysis"
       ],
       "array_option_3": [
         "",

--- a/dashboards/flows-by-science-discipline.json
+++ b/dashboards/flows-by-science-discipline.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1581641229814,
+  "iteration": 1581715305795,
   "links": [],
   "panels": [
     {
@@ -271,7 +271,7 @@
         "show": true
       },
       "links": [],
-      "max_total": 86023529,
+      "max_total": 82899340,
       "option_1": "netsage",
       "option_2": "netsagenavigation",
       "option_3": "plugin",
@@ -279,11 +279,11 @@
       "options": {},
       "parsed_data": [
         {
-          "avg": 509014.9644970414,
+          "avg": 490528.63905325445,
           "label": "Count",
-          "max": 2577118,
-          "min": 5553,
-          "total": 86023529
+          "max": 2600869,
+          "min": 234,
+          "total": 82899340
         }
       ],
       "rgb_values": [
@@ -1109,46 +1109,16 @@
       ],
       "table_data": [
         [
-          "CERN",
-          "MPS.Physics.High Energy",
-          "UNK-DST",
-          300276705595392
-        ],
-        [
-          "CERN",
-          "MPS.Physics.High Energy",
-          "National Energy Research Scientific Computing Center (NERSC)",
-          58012150268152
-        ],
-        [
-          "CERN",
-          "MPS.Physics.High Energy",
-          "University of Oklahoma (OU)",
-          29387851644928
-        ],
-        [
-          "CERN",
-          "MPS.Physics.High Energy",
-          "Chinese University of Hong Kong (CUHK)",
-          4430500474880
-        ],
-        [
-          "CERN",
-          "MPS.Physics.High Energy",
-          "Columbia University",
-          296206868480
-        ],
-        [
           "Brookhaven National Laboratory (BNL)",
           "MPS.Physics.High Energy",
           "UNK-DST",
-          320285878267904
+          351209873383424
         ],
         [
           "Brookhaven National Laboratory (BNL)",
           "MPS.Physics.High Energy",
           "Max Planck Computing and Data Facility (MPCDF)",
-          35584615612416
+          37794422398976
         ],
         [
           "Brookhaven National Laboratory (BNL)",
@@ -1160,19 +1130,19 @@
           "Brookhaven National Laboratory (BNL)",
           "MPS.Physics.High Energy",
           "Gesellschaft fÃ¼r wissenschaftliche Datenverarbeitung mbH GÃ¶ttingen  (GWDG)",
-          5793092100096
+          5680440975360
         ],
         [
           "Brookhaven National Laboratory (BNL)",
           "MPS.Physics.High Energy",
-          "University of Glasgow (U of G)",
-          2255420366848
+          "Chinese University of Hong Kong (CUHK)",
+          3117292773376
         ],
         [
           "University of Chicago (U of C)",
           "MPS.Physics.High Energy",
           "UNK-DST",
-          223736699863496
+          332351004004808
         ],
         [
           "University of Chicago (U of C)",
@@ -1184,25 +1154,55 @@
           "University of Chicago (U of C)",
           "MPS.Physics.High Energy",
           "Chinese University of Hong Kong (CUHK)",
-          1747520802816
+          2626633814016
         ],
         [
           "University of Chicago (U of C)",
           "MPS.Physics.High Energy",
           "Energy Sciences Network (ESnet)",
-          1210953089024
+          1253191639040
+        ],
+        [
+          "CERN",
+          "MPS.Physics.High Energy",
+          "UNK-DST",
+          289572375584768
+        ],
+        [
+          "CERN",
+          "MPS.Physics.High Energy",
+          "University of Oklahoma (OU)",
+          31829915090944
+        ],
+        [
+          "CERN",
+          "MPS.Physics.High Energy",
+          "Chinese University of Hong Kong (CUHK)",
+          4856301678592
+        ],
+        [
+          "CERN",
+          "MPS.Physics.High Energy",
+          "National Energy Research Scientific Computing Center (NERSC)",
+          1265473111624
+        ],
+        [
+          "CERN",
+          "MPS.Physics.High Energy",
+          "Columbia University",
+          306040184832
         ],
         [
           "National Institute for Nuclear Physics - National Center for Frame Analysis",
           "MPS.Physics.High Energy",
           "University of Florida (UF)",
-          158082712305664
+          142709931253760
         ],
         [
           "National Institute for Nuclear Physics - National Center for Frame Analysis",
           "MPS.Physics.High Energy",
           "UNK-DST",
-          15447816339456
+          13657791070208
         ],
         [
           "National Institute for Nuclear Physics - National Center for Frame Analysis",
@@ -1214,43 +1214,43 @@
           "Thomas Jefferson National Accelerator Facility (Jefferson Lab or TJNAF)",
           "MPS.Physics.High Energy",
           "UNK-DST",
-          153907490398760
+          140780915233832
         ],
         [
           "Rutherford Appleton Laboratory (RAL)",
           "MPS.Physics.High Energy",
           "Boston University (BU)",
-          61516747714560
+          69107109179392
+        ],
+        [
+          "Rutherford Appleton Laboratory (RAL)",
+          "MPS.Physics.High Energy",
+          "UNK-DST",
+          11065988616192
         ],
         [
           "Rutherford Appleton Laboratory (RAL)",
           "MPS.Physics.High Energy",
           "SLAC National Accelerator Laboratory",
-          10110584778752
-        ],
-        [
-          "Rutherford Appleton Laboratory (RAL)",
-          "MPS.Physics.High Energy",
-          "UNK-DST",
-          9737252397056
+          11029639090176
         ],
         [
           "Rutherford Appleton Laboratory (RAL)",
           "MPS.Physics.High Energy",
           "National Energy Research Scientific Computing Center (NERSC)",
-          1883789930496
+          1892138758144
         ],
         [
           "Rutherford Appleton Laboratory (RAL)",
           "MPS.Physics.High Energy",
           "Chinese University of Hong Kong (CUHK)",
-          1248360005632
+          1056848084992
         ],
         [
           "Purdue University",
           "MPS.Physics.High Energy",
           "UNK-DST",
-          65251285889408
+          61564263096320
         ],
         [
           "Purdue University",
@@ -1262,43 +1262,67 @@
           "SLAC National Accelerator Laboratory",
           "MPS.Physics.High Energy",
           "UNK-DST",
-          35296485933056
+          39806551097344
         ],
         [
           "SLAC National Accelerator Laboratory",
           "MPS.Physics.High Energy",
           "Queen Mary University of London (QMUL)",
-          4632950562816
+          4743128842240
         ],
         [
           "SLAC National Accelerator Laboratory",
           "MPS.Physics.High Energy",
           "Rutherford Appleton Laboratory (RAL)",
-          2206882918400
+          2245611429888
         ],
         [
           "SLAC National Accelerator Laboratory",
           "MPS.Physics.High Energy",
           "University of Manchester",
-          1156228112384
+          1284168310784
         ],
         [
           "SLAC National Accelerator Laboratory",
           "MPS.Physics.High Energy",
-          "University of Glasgow (U of G)",
-          551259459584
-        ],
-        [
-          "Horia Hulubei National Institute for R&D in Physics and Nuclear Engineering",
-          "MPS.Physics.High Energy",
-          "UNK-DST",
-          35211304894464
+          "Technion - Israel Institute of Technology",
+          531977961472
         ],
         [
           "California Institute of Technology (Caltech)",
           "MPS.Physics.High Energy",
           "UNK-DST",
-          33911925768192
+          43916956991488
+        ],
+        [
+          "University of Manchester",
+          "MPS.Physics.High Energy",
+          "UNK-DST",
+          22301541335040
+        ],
+        [
+          "University of Manchester",
+          "MPS.Physics.High Energy",
+          "Boston University (BU)",
+          9909668732928
+        ],
+        [
+          "University of Manchester",
+          "MPS.Physics.High Energy",
+          "SLAC National Accelerator Laboratory",
+          1419088826368
+        ],
+        [
+          "University of Manchester",
+          "MPS.Physics.High Energy",
+          "National Energy Research Scientific Computing Center (NERSC)",
+          546294157312
+        ],
+        [
+          "University of Manchester",
+          "MPS.Physics.High Energy",
+          "Columbia University",
+          85157814272
         ]
       ],
       "table_data_type": "Sum",
@@ -2471,7 +2495,7 @@
           ],
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
           "decimals": 1,
-          "pattern": "Count",
+          "pattern": "Unique Count",
           "thresholds": [],
           "type": "number",
           "unit": "short"
@@ -2580,9 +2604,11 @@
               "type": "max"
             },
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "9",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             },
             {
               "field": "values.bits_per_second",
@@ -2653,7 +2679,7 @@
           ],
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
           "decimals": 1,
-          "pattern": "Count",
+          "pattern": "Unique Count",
           "thresholds": [],
           "type": "number",
           "unit": "short"
@@ -2762,9 +2788,11 @@
               "type": "max"
             },
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "9",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             },
             {
               "field": "values.bits_per_second",

--- a/dashboards/flows-by-science-discipline.json
+++ b/dashboards/flows-by-science-discipline.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1581578097094,
+  "iteration": 1581641229814,
   "links": [],
   "panels": [
     {
@@ -271,7 +271,7 @@
         "show": true
       },
       "links": [],
-      "max_total": 61004790,
+      "max_total": 86023529,
       "option_1": "netsage",
       "option_2": "netsagenavigation",
       "option_3": "plugin",
@@ -279,11 +279,11 @@
       "options": {},
       "parsed_data": [
         {
-          "avg": 717703.4117647059,
+          "avg": 509014.9644970414,
           "label": "Count",
-          "max": 3303995,
-          "min": 2389,
-          "total": 61004790
+          "max": 2577118,
+          "min": 5553,
+          "total": 86023529
         }
       ],
       "rgb_values": [
@@ -585,9 +585,11 @@
           ],
           "metrics": [
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "1",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "meta.sensor_id.keyword:$Sensors && (meta.scireg.src.discipline.keyword:$discipline OR meta.scireg.dst.discipline.keyword:$discipline)",
@@ -794,9 +796,11 @@
           ],
           "metrics": [
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "1",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "meta.sensor_id.keyword:$Sensors",
@@ -1108,199 +1112,193 @@
           "CERN",
           "MPS.Physics.High Energy",
           "UNK-DST",
-          1560525296197632
+          300276705595392
         ],
         [
           "CERN",
           "MPS.Physics.High Energy",
-          "Chinese University of Hong Kong (CUHK)",
-          5426043359232
+          "National Energy Research Scientific Computing Center (NERSC)",
+          58012150268152
         ],
         [
           "CERN",
           "MPS.Physics.High Energy",
           "University of Oklahoma (OU)",
-          3483709300736
+          29387851644928
         ],
         [
           "CERN",
           "MPS.Physics.High Energy",
-          "National Energy Research Scientific Computing Center (NERSC)",
-          389099347968
+          "Chinese University of Hong Kong (CUHK)",
+          4430500474880
         ],
         [
           "CERN",
           "MPS.Physics.High Energy",
-          "Brookhaven National Laboratory (BNL)",
-          13814792192
+          "Columbia University",
+          296206868480
         ],
         [
           "Brookhaven National Laboratory (BNL)",
           "MPS.Physics.High Energy",
           "UNK-DST",
-          416806859513856
+          320285878267904
         ],
         [
           "Brookhaven National Laboratory (BNL)",
           "MPS.Physics.High Energy",
           "Max Planck Computing and Data Facility (MPCDF)",
-          41794913439744
+          35584615612416
         ],
         [
           "Brookhaven National Laboratory (BNL)",
           "MPS.Physics.High Energy",
-          "University of Glasgow (U of G)",
-          10509724995584
-        ],
-        [
-          "Brookhaven National Laboratory (BNL)",
-          "MPS.Physics.High Energy",
-          "Chinese University of Hong Kong (CUHK)",
-          4525478510592
+          "National Energy Research Scientific Computing Center (NERSC)",
+          25714786217776
         ],
         [
           "Brookhaven National Laboratory (BNL)",
           "MPS.Physics.High Energy",
           "Gesellschaft fÃ¼r wissenschaftliche Datenverarbeitung mbH GÃ¶ttingen  (GWDG)",
-          2096275951616
+          5793092100096
         ],
         [
-          "Massachusetts Institute of Technology (MIT)",
+          "Brookhaven National Laboratory (BNL)",
           "MPS.Physics.High Energy",
-          "UNK-DST",
-          181276649271296
-        ],
-        [
-          "Rutherford Appleton Laboratory (RAL)",
-          "MPS.Physics.High Energy",
-          "Boston University (BU)",
-          55144869879808
-        ],
-        [
-          "Rutherford Appleton Laboratory (RAL)",
-          "MPS.Physics.High Energy",
-          "SLAC National Accelerator Laboratory",
-          22135315968000
-        ],
-        [
-          "Rutherford Appleton Laboratory (RAL)",
-          "MPS.Physics.High Energy",
-          "UNK-DST",
-          148373375352832
-        ],
-        [
-          "Rutherford Appleton Laboratory (RAL)",
-          "MPS.Physics.High Energy",
-          "University of Florida (UF)",
-          100017822478336
-        ],
-        [
-          "Rutherford Appleton Laboratory (RAL)",
-          "MPS.Physics.High Energy",
-          "National Energy Research Scientific Computing Center (NERSC)",
-          159982501888
+          "University of Glasgow (U of G)",
+          2255420366848
         ],
         [
           "University of Chicago (U of C)",
           "MPS.Physics.High Energy",
           "UNK-DST",
-          3785973628928
+          223736699863496
         ],
         [
-          "Fermi National Accelerator Laboratory (Fermilab)",
-          "MPS.Physics.High Energy",
-          "UNK-DST",
-          73856800096256
-        ],
-        [
-          "Fermi National Accelerator Laboratory (Fermilab)",
+          "University of Chicago (U of C)",
           "MPS.Physics.High Energy",
           "National Energy Research Scientific Computing Center (NERSC)",
-          7861560258760
+          11426465234008
         ],
         [
-          "Fermi National Accelerator Laboratory (Fermilab)",
-          "MPS.Physics.High Energy",
-          "National Institute of Chemical Physics and Biophysics (NICPB)",
-          3349154267136
-        ],
-        [
-          "Fermi National Accelerator Laboratory (Fermilab)",
-          "MPS.Physics.High Energy",
-          "National Energy Research Scientific Computing Center (NERSC)",
-          7671075492696
-        ],
-        [
-          "Fermi National Accelerator Laboratory (Fermilab)",
-          "MPS.Physics.High Energy",
-          "UNK-DST",
-          56031477407744
-        ],
-        [
-          "University of Glasgow (U of G)",
-          "MPS.Physics.High Energy",
-          "Brookhaven National Laboratory (BNL)",
-          39315260628992
-        ],
-        [
-          "University of Glasgow (U of G)",
-          "MPS.Physics.High Energy",
-          "UNK-DST",
-          14353087270912
-        ],
-        [
-          "University of Glasgow (U of G)",
-          "MPS.Physics.High Energy",
-          "Boston University (BU)",
-          1016360566784
-        ],
-        [
-          "University of Glasgow (U of G)",
-          "MPS.Physics.High Energy",
-          "SLAC National Accelerator Laboratory",
-          667650764800
-        ],
-        [
-          "University of Glasgow (U of G)",
+          "University of Chicago (U of C)",
           "MPS.Physics.High Energy",
           "Chinese University of Hong Kong (CUHK)",
-          8665751552
+          1747520802816
         ],
         [
-          "Purdue University",
+          "University of Chicago (U of C)",
           "MPS.Physics.High Energy",
-          "Boston University (BU)",
-          26571808403456
+          "Energy Sciences Network (ESnet)",
+          1210953089024
         ],
         [
           "National Institute for Nuclear Physics - National Center for Frame Analysis",
           "MPS.Physics.High Energy",
-          "SLAC National Accelerator Laboratory",
-          17205117317120
+          "University of Florida (UF)",
+          158082712305664
         ],
         [
           "National Institute for Nuclear Physics - National Center for Frame Analysis",
           "MPS.Physics.High Energy",
           "UNK-DST",
-          7874161807360
+          15447816339456
+        ],
+        [
+          "National Institute for Nuclear Physics - National Center for Frame Analysis",
+          "MPS.Physics.High Energy",
+          "Purdue University",
+          739082240
+        ],
+        [
+          "Thomas Jefferson National Accelerator Facility (Jefferson Lab or TJNAF)",
+          "MPS.Physics.High Energy",
+          "UNK-DST",
+          153907490398760
+        ],
+        [
+          "Rutherford Appleton Laboratory (RAL)",
+          "MPS.Physics.High Energy",
+          "Boston University (BU)",
+          61516747714560
+        ],
+        [
+          "Rutherford Appleton Laboratory (RAL)",
+          "MPS.Physics.High Energy",
+          "SLAC National Accelerator Laboratory",
+          10110584778752
+        ],
+        [
+          "Rutherford Appleton Laboratory (RAL)",
+          "MPS.Physics.High Energy",
+          "UNK-DST",
+          9737252397056
+        ],
+        [
+          "Rutherford Appleton Laboratory (RAL)",
+          "MPS.Physics.High Energy",
+          "National Energy Research Scientific Computing Center (NERSC)",
+          1883789930496
         ],
         [
           "Rutherford Appleton Laboratory (RAL)",
           "MPS.Physics.High Energy",
           "Chinese University of Hong Kong (CUHK)",
-          1803576643584
-        ],
-        [
-          "Rutherford Appleton Laboratory (RAL)",
-          "MPS.Physics.High Energy",
-          "Purdue University",
-          11012325376
+          1248360005632
         ],
         [
           "Purdue University",
           "MPS.Physics.High Energy",
           "UNK-DST",
-          44834792997936
+          65251285889408
+        ],
+        [
+          "Purdue University",
+          "MPS.Physics.High Energy",
+          "National Energy Research Scientific Computing Center (NERSC)",
+          69980755760
+        ],
+        [
+          "SLAC National Accelerator Laboratory",
+          "MPS.Physics.High Energy",
+          "UNK-DST",
+          35296485933056
+        ],
+        [
+          "SLAC National Accelerator Laboratory",
+          "MPS.Physics.High Energy",
+          "Queen Mary University of London (QMUL)",
+          4632950562816
+        ],
+        [
+          "SLAC National Accelerator Laboratory",
+          "MPS.Physics.High Energy",
+          "Rutherford Appleton Laboratory (RAL)",
+          2206882918400
+        ],
+        [
+          "SLAC National Accelerator Laboratory",
+          "MPS.Physics.High Energy",
+          "University of Manchester",
+          1156228112384
+        ],
+        [
+          "SLAC National Accelerator Laboratory",
+          "MPS.Physics.High Energy",
+          "University of Glasgow (U of G)",
+          551259459584
+        ],
+        [
+          "Horia Hulubei National Institute for R&D in Physics and Nuclear Engineering",
+          "MPS.Physics.High Energy",
+          "UNK-DST",
+          35211304894464
+        ],
+        [
+          "California Institute of Technology (Caltech)",
+          "MPS.Physics.High Energy",
+          "UNK-DST",
+          33911925768192
         ]
       ],
       "table_data_type": "Sum",
@@ -2811,7 +2809,7 @@
     }
   ],
   "refresh": false,
-  "schemaVersion": 18,
+  "schemaVersion": 19,
   "style": "dark",
   "tags": [
     "flow",

--- a/dashboards/individual-flows-per-country.json
+++ b/dashboards/individual-flows-per-country.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1581640989678,
+  "iteration": 1581716644697,
   "links": [],
   "panels": [
     {
@@ -270,7 +270,7 @@
         "show": true
       },
       "links": [],
-      "max_total": 86060889,
+      "max_total": 82784082,
       "option_1": "netsage",
       "option_2": "maheshtest",
       "option_3": "plugin",
@@ -278,11 +278,11 @@
       "options": {},
       "parsed_data": [
         {
-          "avg": 42667.768468021815,
+          "avg": 41043.174020823004,
           "label": "Count",
-          "max": 469551,
+          "max": 471204,
           "min": 0,
-          "total": 86060889
+          "total": 82784082
         }
       ],
       "rgb_values": [
@@ -3399,11 +3399,11 @@
             "rgba(50, 172, 45, 0.97)"
           ],
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "decimals": 0,
-          "pattern": "Count",
+          "decimals": 1,
+          "pattern": "Unique Count",
           "thresholds": [],
           "type": "number",
-          "unit": "locale"
+          "unit": "short"
         },
         {
           "alias": "Total Volume",
@@ -3515,9 +3515,11 @@
               "type": "max"
             },
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "7",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "((meta.src_country_name.keyword:$src AND meta.dst_country_name.keyword:$dest) OR (meta.src_country_name.keyword:$dest AND meta.dst_country_name.keyword:$src)) AND meta.sensor_id.keyword:$sensor",

--- a/dashboards/individual-flows-per-country.json
+++ b/dashboards/individual-flows-per-country.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1581716644697,
+  "iteration": 1582054970506,
   "links": [],
   "panels": [
     {
@@ -32,8 +32,7 @@
         "What are the bandwidth patterns in the network?",
         "What are the patterns of loss in the network?",
         "What are the patterns of latency in the network?",
-        "What are the current flow data summary statistics?",
-        "Advanced Flow Analysis"
+        "What are the current flow data summary statistics?"
       ],
       "array_option_2": [
         "/grafana/d/000000003/bandwidth-dashboard",
@@ -47,8 +46,7 @@
         "/grafana/d/000000004/bandwidth-patterns",
         "/grafana/d/000000006/loss-patterns",
         "/grafana/d/000000005/latency-patterns",
-        "/grafana/d/CJC1FFhmz/other-flow-stats",
-        "/grafana/d/VuuXrnPWz/flow-analysis"
+        "/grafana/d/CJC1FFhmz/other-flow-stats"
       ],
       "array_option_3": [
         "",
@@ -272,7 +270,7 @@
         "show": true
       },
       "links": [],
-      "max_total": 82784082,
+      "max_total": 61685309,
       "option_1": "netsage",
       "option_2": "maheshtest",
       "option_3": "plugin",
@@ -280,11 +278,11 @@
       "options": {},
       "parsed_data": [
         {
-          "avg": 41043.174020823004,
+          "avg": 30582.701536936045,
           "label": "Count",
-          "max": 471204,
+          "max": 471021,
           "min": 0,
-          "total": 82784082
+          "total": 61685309
         }
       ],
       "rgb_values": [
@@ -686,7 +684,7 @@
               "field": "start",
               "id": "2",
               "settings": {
-                "interval": "1825d",
+                "interval": "auto",
                 "min_doc_count": 0,
                 "trimEdges": 0
               },
@@ -1520,6 +1518,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
+      "decimals": 1,
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1530,13 +1529,14 @@
       },
       "id": 39,
       "legend": {
+        "alignAsTable": true,
         "avg": false,
         "current": false,
-        "max": false,
+        "max": true,
         "min": false,
         "show": false,
-        "total": false,
-        "values": false
+        "total": true,
+        "values": true
       },
       "lines": false,
       "linewidth": 1,
@@ -1563,8 +1563,8 @@
               "settings": {
                 "min_doc_count": 1,
                 "order": "desc",
-                "orderBy": "_count",
-                "size": "10"
+                "orderBy": "1",
+                "size": "5"
               },
               "type": "terms"
             },
@@ -1581,9 +1581,11 @@
           ],
           "metrics": [
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "1",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "meta.src_country_name.keyword:$src AND meta.dst_country_name.keyword:$dest  AND meta.sensor_id.keyword:$sensor AND meta.flow_type.keyword:$flow_type",
@@ -1597,8 +1599,8 @@
       "timeShift": null,
       "title": "Top Protocols",
       "tooltip": {
-        "shared": false,
-        "sort": 0,
+        "shared": true,
+        "sort": 2,
         "value_type": "individual"
       },
       "type": "graph",
@@ -1640,6 +1642,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
+      "decimals": 1,
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1650,13 +1653,14 @@
       },
       "id": 40,
       "legend": {
+        "alignAsTable": true,
         "avg": false,
         "current": false,
-        "max": false,
+        "max": true,
         "min": false,
         "show": false,
-        "total": false,
-        "values": false
+        "total": true,
+        "values": true
       },
       "lines": false,
       "linewidth": 1,
@@ -1683,7 +1687,7 @@
               "settings": {
                 "min_doc_count": 1,
                 "order": "desc",
-                "orderBy": "_count",
+                "orderBy": "1",
                 "size": "5"
               },
               "type": "terms"
@@ -1701,9 +1705,13 @@
           ],
           "metrics": [
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "1",
-              "type": "count"
+              "meta": {},
+              "settings": {
+                "precision_threshold": null
+              },
+              "type": "cardinality"
             }
           ],
           "query": "meta.src_country_name.keyword:$src AND meta.dst_country_name.keyword:$dest  AND meta.sensor_id.keyword:$sensor AND meta.flow_type.keyword:$flow_type",
@@ -1717,8 +1725,8 @@
       "timeShift": null,
       "title": "Top Source Ports",
       "tooltip": {
-        "shared": false,
-        "sort": 0,
+        "shared": true,
+        "sort": 2,
         "value_type": "individual"
       },
       "type": "graph",
@@ -1760,6 +1768,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
+      "decimals": 1,
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1770,13 +1779,14 @@
       },
       "id": 41,
       "legend": {
+        "alignAsTable": true,
         "avg": false,
         "current": false,
-        "max": false,
+        "max": true,
         "min": false,
         "show": false,
-        "total": false,
-        "values": false
+        "total": true,
+        "values": true
       },
       "lines": false,
       "linewidth": 1,
@@ -1803,7 +1813,7 @@
               "settings": {
                 "min_doc_count": 1,
                 "order": "desc",
-                "orderBy": "_count",
+                "orderBy": "1",
                 "size": "5"
               },
               "type": "terms"
@@ -1821,9 +1831,11 @@
           ],
           "metrics": [
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "1",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "meta.src_country_name.keyword:$src AND meta.dst_country_name.keyword:$dest  AND meta.sensor_id.keyword:$sensor AND meta.flow_type.keyword:$flow_type",
@@ -1837,8 +1849,8 @@
       "timeShift": null,
       "title": "Top Destination Ports",
       "tooltip": {
-        "shared": false,
-        "sort": 0,
+        "shared": true,
+        "sort": 2,
         "value_type": "individual"
       },
       "type": "graph",
@@ -2174,7 +2186,7 @@
               "field": "start",
               "id": "2",
               "settings": {
-                "interval": "1825d",
+                "interval": "auto",
                 "min_doc_count": 0,
                 "trimEdges": 0
               },
@@ -2989,6 +3001,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
+      "decimals": 1,
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -2999,13 +3012,14 @@
       },
       "id": 59,
       "legend": {
+        "alignAsTable": true,
         "avg": false,
         "current": false,
-        "max": false,
+        "max": true,
         "min": false,
         "show": false,
-        "total": false,
-        "values": false
+        "total": true,
+        "values": true
       },
       "lines": false,
       "linewidth": 1,
@@ -3032,8 +3046,8 @@
               "settings": {
                 "min_doc_count": 1,
                 "order": "desc",
-                "orderBy": "_count",
-                "size": "10"
+                "orderBy": "1",
+                "size": "5"
               },
               "type": "terms"
             },
@@ -3050,9 +3064,11 @@
           ],
           "metrics": [
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "1",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "meta.src_country_name.keyword:$dest AND meta.dst_country_name.keyword:$src  AND meta.sensor_id.keyword:$sensor AND meta.flow_type.keyword:$flow_type",
@@ -3066,8 +3082,8 @@
       "timeShift": null,
       "title": "Top Protocols",
       "tooltip": {
-        "shared": false,
-        "sort": 0,
+        "shared": true,
+        "sort": 2,
         "value_type": "individual"
       },
       "type": "graph",
@@ -3109,6 +3125,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
+      "decimals": 1,
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -3119,13 +3136,14 @@
       },
       "id": 60,
       "legend": {
+        "alignAsTable": true,
         "avg": false,
         "current": false,
-        "max": false,
+        "max": true,
         "min": false,
         "show": false,
-        "total": false,
-        "values": false
+        "total": true,
+        "values": true
       },
       "lines": false,
       "linewidth": 1,
@@ -3152,7 +3170,7 @@
               "settings": {
                 "min_doc_count": 1,
                 "order": "desc",
-                "orderBy": "_count",
+                "orderBy": "1",
                 "size": "5"
               },
               "type": "terms"
@@ -3170,9 +3188,11 @@
           ],
           "metrics": [
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "1",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "meta.src_country_name.keyword:$dest AND meta.dst_country_name.keyword:$src  AND meta.sensor_id.keyword:$sensor AND meta.flow_type.keyword:$flow_type",
@@ -3186,8 +3206,8 @@
       "timeShift": null,
       "title": "Top Source Ports",
       "tooltip": {
-        "shared": false,
-        "sort": 0,
+        "shared": true,
+        "sort": 2,
         "value_type": "individual"
       },
       "type": "graph",
@@ -3229,6 +3249,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
+      "decimals": 1,
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -3239,13 +3260,14 @@
       },
       "id": 61,
       "legend": {
+        "alignAsTable": true,
         "avg": false,
         "current": false,
-        "max": false,
+        "max": true,
         "min": false,
         "show": false,
-        "total": false,
-        "values": false
+        "total": true,
+        "values": true
       },
       "lines": false,
       "linewidth": 1,
@@ -3272,7 +3294,7 @@
               "settings": {
                 "min_doc_count": 1,
                 "order": "desc",
-                "orderBy": "_count",
+                "orderBy": "1",
                 "size": "5"
               },
               "type": "terms"
@@ -3290,9 +3312,11 @@
           ],
           "metrics": [
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "1",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "meta.src_country_name.keyword:$dest AND meta.dst_country_name.keyword:$src  AND meta.sensor_id.keyword:$sensor AND meta.flow_type.keyword:$flow_type",
@@ -3306,8 +3330,8 @@
       "timeShift": null,
       "title": "Top Destination Ports",
       "tooltip": {
-        "shared": false,
-        "sort": 0,
+        "shared": true,
+        "sort": 2,
         "value_type": "individual"
       },
       "type": "graph",

--- a/dashboards/individual-flows-per-country.json
+++ b/dashboards/individual-flows-per-country.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1581608166564,
+  "iteration": 1581640989678,
   "links": [],
   "panels": [
     {
@@ -270,7 +270,7 @@
         "show": true
       },
       "links": [],
-      "max_total": 61435064,
+      "max_total": 86060889,
       "option_1": "netsage",
       "option_2": "maheshtest",
       "option_3": "plugin",
@@ -278,11 +278,11 @@
       "options": {},
       "parsed_data": [
         {
-          "avg": 60887.08027750248,
+          "avg": 42667.768468021815,
           "label": "Count",
-          "max": 627259,
+          "max": 469551,
           "min": 0,
-          "total": 61435064
+          "total": 86060889
         }
       ],
       "rgb_values": [
@@ -481,7 +481,7 @@
               "id": "1",
               "meta": {},
               "settings": {},
-              "type": "count"
+              "type": "cardinality"
             }
           ],
           "query": "meta.src_country_name.keyword:$src AND meta.dst_country_name.keyword:$dest  AND meta.sensor_id.keyword:$sensor AND meta.flow_type.keyword:$flow_type",
@@ -1969,7 +1969,7 @@
               "id": "1",
               "meta": {},
               "settings": {},
-              "type": "count"
+              "type": "cardinality"
             }
           ],
           "query": "meta.src_country_name.keyword:$dest AND meta.dst_country_name.keyword:$src  AND meta.sensor_id.keyword:$sensor AND meta.flow_type.keyword:$flow_type",

--- a/dashboards/individual-flows-per-country.json
+++ b/dashboards/individual-flows-per-country.json
@@ -32,7 +32,8 @@
         "What are the bandwidth patterns in the network?",
         "What are the patterns of loss in the network?",
         "What are the patterns of latency in the network?",
-        "What are the current flow data summary statistics?"
+        "What are the current flow data summary statistics?",
+        "Advanced Flow Analysis"
       ],
       "array_option_2": [
         "/grafana/d/000000003/bandwidth-dashboard",
@@ -46,7 +47,8 @@
         "/grafana/d/000000004/bandwidth-patterns",
         "/grafana/d/000000006/loss-patterns",
         "/grafana/d/000000005/latency-patterns",
-        "/grafana/d/CJC1FFhmz/other-flow-stats"
+        "/grafana/d/CJC1FFhmz/other-flow-stats",
+        "/grafana/d/VuuXrnPWz/flow-analysis"
       ],
       "array_option_3": [
         "",

--- a/dashboards/individual-flows.json
+++ b/dashboards/individual-flows.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1581715769301,
+  "iteration": 1582054974673,
   "links": [],
   "panels": [
     {
@@ -32,8 +32,7 @@
         "What are the bandwidth patterns in the network?",
         "What are the patterns of loss in the network?",
         "What are the patterns of latency in the network?",
-        "What are the current flow data summary statistics?",
-        "Advanced Flow Analysis"
+        "What are the current flow data summary statistics?"
       ],
       "array_option_2": [
         "/grafana/d/000000003/bandwidth-dashboard",
@@ -47,8 +46,7 @@
         "/grafana/d/000000004/bandwidth-patterns",
         "/grafana/d/000000006/loss-patterns",
         "/grafana/d/000000005/latency-patterns",
-        "/grafana/d/CJC1FFhmz/other-flow-stats",
-        "/grafana/d/VuuXrnPWz/flow-analysis"
+        "/grafana/d/CJC1FFhmz/other-flow-stats"
       ],
       "array_option_3": [
         "",
@@ -272,7 +270,7 @@
         "show": true
       },
       "links": [],
-      "max_total": 82859188,
+      "max_total": 61672460,
       "option_1": "netsage",
       "option_2": "maheshtest",
       "option_3": "plugin",
@@ -280,11 +278,11 @@
       "options": {},
       "parsed_data": [
         {
-          "avg": 490291.05325443787,
+          "avg": 364925.79881656804,
           "label": "Count",
-          "max": 2600869,
-          "min": 3277,
-          "total": 82859188
+          "max": 1839113,
+          "min": 366,
+          "total": 61672460
         }
       ],
       "rgb_values": [
@@ -686,7 +684,7 @@
               "field": "start",
               "id": "2",
               "settings": {
-                "interval": "1825d",
+                "interval": "auto",
                 "min_doc_count": 0,
                 "trimEdges": 0
               },
@@ -1520,6 +1518,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
+      "decimals": 1,
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1530,13 +1529,14 @@
       },
       "id": 39,
       "legend": {
+        "alignAsTable": true,
         "avg": false,
         "current": false,
-        "max": false,
+        "max": true,
         "min": false,
         "show": false,
-        "total": false,
-        "values": false
+        "total": true,
+        "values": true
       },
       "lines": false,
       "linewidth": 1,
@@ -1563,8 +1563,8 @@
               "settings": {
                 "min_doc_count": 1,
                 "order": "desc",
-                "orderBy": "_count",
-                "size": "10"
+                "orderBy": "1",
+                "size": "5"
               },
               "type": "terms"
             },
@@ -1581,9 +1581,11 @@
           ],
           "metrics": [
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "1",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "meta.src_organization.keyword:$src AND meta.dst_organization.keyword:$dest AND meta.sensor_id.keyword:$sensor AND meta.flow_type.keyword:$flow_type",
@@ -1597,8 +1599,8 @@
       "timeShift": null,
       "title": "Top Protocols",
       "tooltip": {
-        "shared": false,
-        "sort": 0,
+        "shared": true,
+        "sort": 2,
         "value_type": "individual"
       },
       "type": "graph",
@@ -1640,6 +1642,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
+      "decimals": 1,
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1650,13 +1653,14 @@
       },
       "id": 40,
       "legend": {
+        "alignAsTable": true,
         "avg": false,
         "current": false,
-        "max": false,
+        "max": true,
         "min": false,
         "show": false,
-        "total": false,
-        "values": false
+        "total": true,
+        "values": true
       },
       "lines": false,
       "linewidth": 1,
@@ -1683,7 +1687,7 @@
               "settings": {
                 "min_doc_count": 1,
                 "order": "desc",
-                "orderBy": "_count",
+                "orderBy": "1",
                 "size": "5"
               },
               "type": "terms"
@@ -1701,9 +1705,11 @@
           ],
           "metrics": [
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "1",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "meta.src_organization.keyword:$src AND meta.dst_organization.keyword:$dest AND meta.sensor_id.keyword:$sensor AND meta.flow_type.keyword:$flow_type",
@@ -1717,8 +1723,8 @@
       "timeShift": null,
       "title": "Top Source Ports",
       "tooltip": {
-        "shared": false,
-        "sort": 0,
+        "shared": true,
+        "sort": 2,
         "value_type": "individual"
       },
       "type": "graph",
@@ -1760,6 +1766,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
+      "decimals": 1,
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1770,13 +1777,14 @@
       },
       "id": 41,
       "legend": {
+        "alignAsTable": true,
         "avg": false,
         "current": false,
-        "max": false,
+        "max": true,
         "min": false,
         "show": false,
-        "total": false,
-        "values": false
+        "total": true,
+        "values": true
       },
       "lines": false,
       "linewidth": 1,
@@ -1803,7 +1811,7 @@
               "settings": {
                 "min_doc_count": 1,
                 "order": "desc",
-                "orderBy": "_count",
+                "orderBy": "1",
                 "size": "5"
               },
               "type": "terms"
@@ -1821,9 +1829,11 @@
           ],
           "metrics": [
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "1",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "meta.src_organization.keyword:$src AND meta.dst_organization.keyword:$dest AND meta.sensor_id.keyword:$sensor AND meta.flow_type.keyword:$flow_type",
@@ -1837,8 +1847,8 @@
       "timeShift": null,
       "title": "Top Destination Ports",
       "tooltip": {
-        "shared": false,
-        "sort": 0,
+        "shared": true,
+        "sort": 2,
         "value_type": "individual"
       },
       "type": "graph",
@@ -2174,7 +2184,7 @@
               "field": "start",
               "id": "2",
               "settings": {
-                "interval": "1825d",
+                "interval": "auto",
                 "min_doc_count": 0,
                 "trimEdges": 0
               },
@@ -2989,6 +2999,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
+      "decimals": 1,
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -2999,13 +3010,14 @@
       },
       "id": 59,
       "legend": {
+        "alignAsTable": true,
         "avg": false,
         "current": false,
-        "max": false,
+        "max": true,
         "min": false,
         "show": false,
-        "total": false,
-        "values": false
+        "total": true,
+        "values": true
       },
       "lines": false,
       "linewidth": 1,
@@ -3032,8 +3044,8 @@
               "settings": {
                 "min_doc_count": 1,
                 "order": "desc",
-                "orderBy": "_count",
-                "size": "10"
+                "orderBy": "1",
+                "size": "5"
               },
               "type": "terms"
             },
@@ -3050,9 +3062,11 @@
           ],
           "metrics": [
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "1",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "meta.src_organization.keyword:$dest AND meta.dst_organization.keyword:$src AND meta.sensor_id.keyword:$sensor AND meta.flow_type.keyword:$flow_type",
@@ -3066,8 +3080,8 @@
       "timeShift": null,
       "title": "Top Protocols",
       "tooltip": {
-        "shared": false,
-        "sort": 0,
+        "shared": true,
+        "sort": 2,
         "value_type": "individual"
       },
       "type": "graph",
@@ -3109,6 +3123,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
+      "decimals": 1,
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -3119,13 +3134,14 @@
       },
       "id": 60,
       "legend": {
+        "alignAsTable": true,
         "avg": false,
         "current": false,
-        "max": false,
+        "max": true,
         "min": false,
         "show": false,
-        "total": false,
-        "values": false
+        "total": true,
+        "values": true
       },
       "lines": false,
       "linewidth": 1,
@@ -3152,7 +3168,7 @@
               "settings": {
                 "min_doc_count": 1,
                 "order": "desc",
-                "orderBy": "_count",
+                "orderBy": "1",
                 "size": "5"
               },
               "type": "terms"
@@ -3170,9 +3186,11 @@
           ],
           "metrics": [
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "1",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "meta.src_organization.keyword:$dest AND meta.dst_organization.keyword:$src AND meta.sensor_id.keyword:$sensor AND meta.flow_type.keyword:$flow_type",
@@ -3186,8 +3204,8 @@
       "timeShift": null,
       "title": "Top Source Ports",
       "tooltip": {
-        "shared": false,
-        "sort": 0,
+        "shared": true,
+        "sort": 2,
         "value_type": "individual"
       },
       "type": "graph",
@@ -3229,6 +3247,7 @@
       "cacheTimeout": null,
       "dashLength": 10,
       "dashes": false,
+      "decimals": 1,
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -3239,13 +3258,14 @@
       },
       "id": 61,
       "legend": {
+        "alignAsTable": true,
         "avg": false,
         "current": false,
-        "max": false,
+        "max": true,
         "min": false,
         "show": false,
-        "total": false,
-        "values": false
+        "total": true,
+        "values": true
       },
       "lines": false,
       "linewidth": 1,
@@ -3272,7 +3292,7 @@
               "settings": {
                 "min_doc_count": 1,
                 "order": "desc",
-                "orderBy": "_count",
+                "orderBy": "1",
                 "size": "5"
               },
               "type": "terms"
@@ -3290,9 +3310,11 @@
           ],
           "metrics": [
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "1",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "meta.src_organization.keyword:$dest AND meta.dst_organization.keyword:$src AND meta.sensor_id.keyword:$sensor AND meta.flow_type.keyword:$flow_type",
@@ -3306,8 +3328,8 @@
       "timeShift": null,
       "title": "Top Destination Ports",
       "tooltip": {
-        "shared": false,
-        "sort": 0,
+        "shared": true,
+        "sort": 2,
         "value_type": "individual"
       },
       "type": "graph",

--- a/dashboards/individual-flows.json
+++ b/dashboards/individual-flows.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1581607863035,
+  "iteration": 1581640373040,
   "links": [],
   "panels": [
     {
@@ -270,7 +270,7 @@
         "show": true
       },
       "links": [],
-      "max_total": 61386419,
+      "max_total": 86216031,
       "option_1": "netsage",
       "option_2": "maheshtest",
       "option_3": "plugin",
@@ -278,11 +278,11 @@
       "options": {},
       "parsed_data": [
         {
-          "avg": 722193.1647058823,
+          "avg": 510154.0295857988,
           "label": "Count",
-          "max": 3883593,
-          "min": 362,
-          "total": 61386419
+          "max": 2577118,
+          "min": 5553,
+          "total": 86216031
         }
       ],
       "rgb_values": [
@@ -481,7 +481,7 @@
               "id": "1",
               "meta": {},
               "settings": {},
-              "type": "count"
+              "type": "cardinality"
             }
           ],
           "query": "meta.src_organization.keyword:$src AND meta.dst_organization.keyword:$dest  AND meta.sensor_id.keyword:$sensor AND meta.flow_type.keyword:$flow_type",
@@ -1969,7 +1969,7 @@
               "id": "1",
               "meta": {},
               "settings": {},
-              "type": "count"
+              "type": "cardinality"
             }
           ],
           "query": "meta.src_organization.keyword:$dest AND meta.dst_organization.keyword:$src  AND meta.sensor_id.keyword:$sensor AND meta.flow_type.keyword:$flow_type",

--- a/dashboards/individual-flows.json
+++ b/dashboards/individual-flows.json
@@ -32,7 +32,8 @@
         "What are the bandwidth patterns in the network?",
         "What are the patterns of loss in the network?",
         "What are the patterns of latency in the network?",
-        "What are the current flow data summary statistics?"
+        "What are the current flow data summary statistics?",
+        "Advanced Flow Analysis"
       ],
       "array_option_2": [
         "/grafana/d/000000003/bandwidth-dashboard",
@@ -46,7 +47,8 @@
         "/grafana/d/000000004/bandwidth-patterns",
         "/grafana/d/000000006/loss-patterns",
         "/grafana/d/000000005/latency-patterns",
-        "/grafana/d/CJC1FFhmz/other-flow-stats"
+        "/grafana/d/CJC1FFhmz/other-flow-stats",
+        "/grafana/d/VuuXrnPWz/flow-analysis"
       ],
       "array_option_3": [
         "",

--- a/dashboards/individual-flows.json
+++ b/dashboards/individual-flows.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1581640373040,
+  "iteration": 1581715769301,
   "links": [],
   "panels": [
     {
@@ -270,7 +270,7 @@
         "show": true
       },
       "links": [],
-      "max_total": 86216031,
+      "max_total": 82859188,
       "option_1": "netsage",
       "option_2": "maheshtest",
       "option_3": "plugin",
@@ -278,11 +278,11 @@
       "options": {},
       "parsed_data": [
         {
-          "avg": 510154.0295857988,
+          "avg": 490291.05325443787,
           "label": "Count",
-          "max": 2577118,
-          "min": 5553,
-          "total": 86216031
+          "max": 2600869,
+          "min": 3277,
+          "total": 82859188
         }
       ],
       "rgb_values": [
@@ -3399,11 +3399,11 @@
             "rgba(50, 172, 45, 0.97)"
           ],
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "decimals": 0,
-          "pattern": "Count",
+          "decimals": 1,
+          "pattern": "Unique Count",
           "thresholds": [],
           "type": "number",
-          "unit": "locale"
+          "unit": "short"
         },
         {
           "alias": "Total Volume",
@@ -3515,9 +3515,11 @@
               "type": "max"
             },
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "7",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "((meta.src_organization.keyword:$src AND meta.dst_organization.keyword:$dest) OR  (meta.src_organization.keyword:$dest AND meta.dst_organization.keyword:$src)) AND meta.sensor_id.keyword:$sensor",

--- a/dashboards/other-flow-stats.json
+++ b/dashboards/other-flow-stats.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1581605439625,
+  "iteration": 1581641826600,
   "links": [],
   "panels": [
     {
@@ -271,7 +271,7 @@
         "show": true
       },
       "links": [],
-      "max_total": 60973213,
+      "max_total": 85982680,
       "option_1": "netsage",
       "option_2": "netsagenavigation",
       "option_3": "plugin",
@@ -279,11 +279,11 @@
       "options": {},
       "parsed_data": [
         {
-          "avg": 717331.9176470588,
+          "avg": 508773.2544378698,
           "label": "Count",
-          "max": 3303995,
-          "min": 2389,
-          "total": 60973213
+          "max": 2577118,
+          "min": 5553,
+          "total": 85982680
         }
       ],
       "rgb_values": [
@@ -475,9 +475,11 @@
           ],
           "metrics": [
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "1",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "meta.sensor_id.keyword:$sensors",
@@ -577,9 +579,11 @@
           ],
           "metrics": [
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "1",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "meta.sensor_id.keyword:$sensors AND ( _exists_:meta.scireg.src.org_name.keyword  OR _exists_:meta.scireg.dst.org_name.keyword  ) AND NOT ( _exists_:meta.scireg.src.org_name.keyword  AND _exists_:meta.scireg.dst.org_name.keyword  )",
@@ -697,9 +701,11 @@
           ],
           "metrics": [
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "1",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "meta.sensor_id.keyword:$sensors AND ( _exists_:meta.scireg.src.org_name.keyword  AND _exists_:meta.scireg.dst.org_name.keyword  )",
@@ -2025,8 +2031,10 @@
               "type": "max"
             },
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "7",
+              "meta": {},
+              "settings": {},
               "type": "count"
             }
           ],

--- a/dashboards/other-flow-stats.json
+++ b/dashboards/other-flow-stats.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1581641826600,
+  "iteration": 1581711751098,
   "links": [],
   "panels": [
     {
@@ -271,7 +271,7 @@
         "show": true
       },
       "links": [],
-      "max_total": 85982680,
+      "max_total": 83229645,
       "option_1": "netsage",
       "option_2": "netsagenavigation",
       "option_3": "plugin",
@@ -279,11 +279,11 @@
       "options": {},
       "parsed_data": [
         {
-          "avg": 508773.2544378698,
+          "avg": 492483.10650887573,
           "label": "Count",
-          "max": 2577118,
-          "min": 5553,
-          "total": 85982680
+          "max": 2600869,
+          "min": 221,
+          "total": 83229645
         }
       ],
       "rgb_values": [
@@ -1899,7 +1899,7 @@
           ],
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
           "decimals": 1,
-          "pattern": "Count",
+          "pattern": "Unique Count",
           "thresholds": [],
           "type": "number",
           "unit": "short"
@@ -2035,7 +2035,7 @@
               "id": "7",
               "meta": {},
               "settings": {},
-              "type": "count"
+              "type": "cardinality"
             }
           ],
           "query": "meta.sensor_id.keyword:$sensors",

--- a/dashboards/other-flow-stats.json
+++ b/dashboards/other-flow-stats.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1581711751098,
+  "iteration": 1582058414542,
   "links": [],
   "panels": [
     {
@@ -32,8 +32,7 @@
         "What are the bandwidth patterns in the network?",
         "What are the patterns of loss in the network?",
         "What are the patterns of latency in the network?",
-        "What are the current flow data summary statistics?",
-        "Advanced Flow Analysis"
+        "What are the current flow data summary statistics?"
       ],
       "array_option_2": [
         "/grafana/d/000000003/bandwidth-dashboard",
@@ -47,8 +46,7 @@
         "/grafana/d/000000004/bandwidth-patterns",
         "/grafana/d/000000006/loss-patterns",
         "/grafana/d/000000005/latency-patterns",
-        "/grafana/d/CJC1FFhmz/other-flow-stats",
-        "/grafana/d/VuuXrnPWz/flow-analysis"
+        "/grafana/d/CJC1FFhmz/other-flow-stats"
       ],
       "array_option_3": [
         "",
@@ -273,7 +271,7 @@
         "show": true
       },
       "links": [],
-      "max_total": 83229645,
+      "max_total": 61302701,
       "option_1": "netsage",
       "option_2": "netsagenavigation",
       "option_3": "plugin",
@@ -281,11 +279,11 @@
       "options": {},
       "parsed_data": [
         {
-          "avg": 492483.10650887573,
+          "avg": 362737.875739645,
           "label": "Count",
-          "max": 2600869,
-          "min": 221,
-          "total": 83229645
+          "max": 1839113,
+          "min": 366,
+          "total": 61302701
         }
       ],
       "rgb_values": [
@@ -1506,9 +1504,9 @@
         "alignAsTable": true,
         "avg": false,
         "current": false,
-        "max": false,
+        "max": true,
         "min": false,
-        "rightSide": true,
+        "rightSide": false,
         "show": false,
         "total": true,
         "values": true
@@ -1538,8 +1536,8 @@
               "settings": {
                 "min_doc_count": 1,
                 "order": "desc",
-                "orderBy": "_count",
-                "size": "10"
+                "orderBy": "1",
+                "size": "5"
               },
               "type": "terms"
             },
@@ -1556,9 +1554,11 @@
           ],
           "metrics": [
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "1",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "meta.sensor_id.keyword:$sensors",
@@ -1570,7 +1570,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Flows by Protocol",
+      "title": "Top Protocols",
       "tooltip": {
         "shared": true,
         "sort": 2,
@@ -1662,8 +1662,8 @@
               "settings": {
                 "min_doc_count": 1,
                 "order": "desc",
-                "orderBy": "_count",
-                "size": "10"
+                "orderBy": "1",
+                "size": "5"
               },
               "type": "terms"
             },
@@ -1680,9 +1680,11 @@
           ],
           "metrics": [
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "1",
-              "type": "count"
+              "meta": {},
+              "settings": {},
+              "type": "cardinality"
             }
           ],
           "query": "-meta.src_port:0 AND meta.sensor_id.keyword:$sensors",
@@ -1694,7 +1696,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Flows by Source Port",
+      "title": "Top Source Ports",
       "tooltip": {
         "shared": true,
         "sort": 2,
@@ -1786,8 +1788,8 @@
               "settings": {
                 "min_doc_count": 1,
                 "order": "desc",
-                "orderBy": "_count",
-                "size": "10"
+                "orderBy": "1",
+                "size": "5"
               },
               "type": "terms"
             },
@@ -1804,9 +1806,13 @@
           ],
           "metrics": [
             {
-              "field": "select field",
+              "field": "meta.id.keyword",
               "id": "1",
-              "type": "count"
+              "meta": {},
+              "settings": {
+                "precision_threshold": null
+              },
+              "type": "cardinality"
             }
           ],
           "query": "-meta.dst_port:0 AND meta.sensor_id.keyword:$sensors",
@@ -1818,7 +1824,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Flows by Destination Port",
+      "title": "Top Destination Ports",
       "tooltip": {
         "shared": true,
         "sort": 2,

--- a/dashboards/other-flow-stats.json
+++ b/dashboards/other-flow-stats.json
@@ -32,7 +32,8 @@
         "What are the bandwidth patterns in the network?",
         "What are the patterns of loss in the network?",
         "What are the patterns of latency in the network?",
-        "What are the current flow data summary statistics?"
+        "What are the current flow data summary statistics?",
+        "Advanced Flow Analysis"
       ],
       "array_option_2": [
         "/grafana/d/000000003/bandwidth-dashboard",
@@ -46,7 +47,8 @@
         "/grafana/d/000000004/bandwidth-patterns",
         "/grafana/d/000000006/loss-patterns",
         "/grafana/d/000000005/latency-patterns",
-        "/grafana/d/CJC1FFhmz/other-flow-stats"
+        "/grafana/d/CJC1FFhmz/other-flow-stats",
+        "/grafana/d/VuuXrnPWz/flow-analysis"
       ],
       "array_option_3": [
         "",


### PR DESCRIPTION
This PR does the following

- Uses unique count instead of count for Total Flows in Single Stat panels
- Uses unique count instead of count for # flows in tables
- Converts # flows from locale format to short in certain tables
- Uses unique count for Top Protocols, Top Source Ports, Top Destination Ports and change headings for these charts