### PR TITLE
Revert analysis dashboard to old version

### DIFF
--- a/dashboards/flow-analysis.json
+++ b/dashboards/flow-analysis.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1584661315160,
+  "iteration": 1587436656061,
   "links": [],
   "panels": [
     {
@@ -851,7 +851,7 @@
               "type": "max"
             }
           ],
-          "query": "meta.sensor_id.keyword:$sensors AND -$src_scope:\"\" AND -$dst_scope:\"\" AND values.num_bits:>$volume_over AND values.bits_per_second:<$rate_under",
+          "query": "meta.sensor_id.keyword:$sensors AND -$src_scope:\"\" AND -$dst_scope:\"\"",
           "refId": "A",
           "timeField": "start"
         }
@@ -1039,7 +1039,7 @@
               "type": "cardinality"
             }
           ],
-          "query": "meta.sensor_id.keyword:$sensors AND -$src_scope:\"\" AND values.num_bits:>$volume_over AND values.bits_per_second:<$rate_under",
+          "query": "meta.sensor_id.keyword:$sensors AND -$src_scope:\"\"",
           "refId": "A",
           "timeField": "start"
         }
@@ -1128,7 +1128,7 @@
               "type": "sum"
             }
           ],
-          "query": "meta.sensor_id.keyword:$sensors AND -$src_scope:\"\" AND values.num_bits:>$volume_over AND values.bits_per_second:<$rate_under",
+          "query": "meta.sensor_id.keyword:$sensors AND -$src_scope:\"\"",
           "refId": "A",
           "timeField": "start"
         }
@@ -1303,7 +1303,7 @@
               "type": "cardinality"
             }
           ],
-          "query": "meta.sensor_id.keyword:$sensors AND -$src_scope:\"\" AND values.num_bits:>$volume_over AND values.bits_per_second:<$rate_under",
+          "query": "meta.sensor_id.keyword:$sensors AND -$src_scope:\"\"",
           "refId": "A",
           "timeField": "start"
         }
@@ -1388,7 +1388,7 @@
               "type": "max"
             }
           ],
-          "query": "meta.sensor_id.keyword:$sensors AND -$src_scope:\"\" AND values.num_bits:>$volume_over AND values.bits_per_second:<$rate_under",
+          "query": "meta.sensor_id.keyword:$sensors AND -$src_scope:\"\"",
           "refId": "A",
           "timeField": "start"
         }
@@ -1616,7 +1616,7 @@
               "type": "cardinality"
             }
           ],
-          "query": "meta.sensor_id.keyword:$sensors AND -$dst_scope:\"\" AND values.num_bits:>$volume_over AND values.bits_per_second:<$rate_under",
+          "query": "meta.sensor_id.keyword:$sensors AND -$dst_scope:\"\"",
           "refId": "A",
           "timeField": "start"
         }
@@ -1705,7 +1705,7 @@
               "type": "sum"
             }
           ],
-          "query": "meta.sensor_id.keyword:$sensors AND -$dst_scope:\"\" AND values.num_bits:>$volume_over AND values.bits_per_second:<$rate_under",
+          "query": "meta.sensor_id.keyword:$sensors AND -$dst_scope:\"\"",
           "refId": "A",
           "timeField": "start"
         }
@@ -1880,7 +1880,7 @@
               "type": "cardinality"
             }
           ],
-          "query": "meta.sensor_id.keyword:$sensors AND -$dst_scope:\"\" AND values.num_bits:>$volume_over AND values.bits_per_second:<$rate_under",
+          "query": "meta.sensor_id.keyword:$sensors AND -$dst_scope:\"\"",
           "refId": "A",
           "timeField": "start"
         }
@@ -1966,7 +1966,7 @@
               "type": "max"
             }
           ],
-          "query": "meta.sensor_id.keyword:$sensors AND -$dst_scope:\"\" AND values.num_bits:>$volume_over AND values.bits_per_second:<$rate_under",
+          "query": "meta.sensor_id.keyword:$sensors AND -$dst_scope:\"\"",
           "refId": "A",
           "timeField": "start"
         }
@@ -2416,7 +2416,7 @@
               "type": "avg"
             }
           ],
-          "query": "meta.sensor_id.keyword:$sensors AND -$src_scope:\"\" AND -$dst_scope:\"\" AND values.num_bits:>$volume_over AND values.bits_per_second:<$rate_under",
+          "query": "meta.sensor_id.keyword:$sensors AND -$src_scope:\"\" AND -$dst_scope:\"\"",
           "refId": "A",
           "timeField": "start"
         }
@@ -2525,7 +2525,7 @@
               "type": "cardinality"
             }
           ],
-          "query": "meta.sensor_id.keyword:$sensors AND values.num_bits:>$volume_over AND values.bits_per_second:<$rate_under",
+          "query": "meta.sensor_id.keyword:$sensors",
           "refId": "A",
           "timeField": "start"
         }
@@ -2621,7 +2621,7 @@
               "type": "cardinality"
             }
           ],
-          "query": "meta.sensor_id.keyword:$sensors AND values.num_bits:>$volume_over AND values.bits_per_second:<$rate_under",
+          "query": "meta.sensor_id.keyword:$sensors",
           "refId": "A",
           "timeField": "start"
         }
@@ -2746,7 +2746,7 @@
               "type": "cardinality"
             }
           ],
-          "query": "meta.sensor_id.keyword:$sensors AND values.num_bits:>$volume_over AND values.bits_per_second:<$rate_under",
+          "query": "meta.sensor_id.keyword:$sensors",
           "refId": "A",
           "timeField": "start"
         }
@@ -2868,7 +2868,7 @@
               "type": "cardinality"
             }
           ],
-          "query": "meta.sensor_id.keyword:$sensors AND values.num_bits:>$volume_over AND values.bits_per_second:<$rate_under",
+          "query": "meta.sensor_id.keyword:$sensors",
           "refId": "A",
           "timeField": "start"
         }
@@ -3097,7 +3097,7 @@
               "type": "cardinality"
             }
           ],
-          "query": "meta.sensor_id.keyword:$sensors AND values.num_bits:>$volume_over AND values.bits_per_second:<$rate_under",
+          "query": "meta.sensor_id.keyword:$sensors",
           "refId": "A",
           "timeField": "start"
         }
@@ -3268,101 +3268,6 @@
           }
         ],
         "query": "meta.dst_organization.keyword, meta.dst_country_name.keyword, meta.dst_continent.keyword, meta.dst_asn, meta.dst_port",
-        "skipUrlSync": false,
-        "type": "custom"
-      },
-      {
-        "allValue": null,
-        "current": {
-          "tags": [],
-          "text": "0",
-          "value": "0"
-        },
-        "hide": 0,
-        "includeAll": false,
-        "label": "Individual Flow Volume Above (in bits)",
-        "multi": false,
-        "name": "volume_over",
-        "options": [
-          {
-            "selected": true,
-            "text": "0",
-            "value": "0"
-          },
-          {
-            "selected": false,
-            "text": "800000000",
-            "value": "800000000"
-          },
-          {
-            "selected": false,
-            "text": "8000000000",
-            "value": "8000000000"
-          },
-          {
-            "selected": false,
-            "text": "80000000000",
-            "value": "80000000000"
-          },
-          {
-            "selected": false,
-            "text": "800000000000",
-            "value": "800000000000"
-          }
-        ],
-        "query": "0, 800000000, 8000000000, 80000000000, 800000000000",
-        "skipUrlSync": false,
-        "type": "custom"
-      },
-      {
-        "allValue": null,
-        "current": {
-          "text": "100000000000",
-          "value": "100000000000"
-        },
-        "hide": 0,
-        "includeAll": false,
-        "label": "Individual Flow Rate Under (in bits per second)",
-        "multi": false,
-        "name": "rate_under",
-        "options": [
-          {
-            "selected": false,
-            "text": "100000",
-            "value": "100000"
-          },
-          {
-            "selected": false,
-            "text": "1000000",
-            "value": "1000000"
-          },
-          {
-            "selected": false,
-            "text": "10000000",
-            "value": "10000000"
-          },
-          {
-            "selected": false,
-            "text": "100000000",
-            "value": "100000000"
-          },
-          {
-            "selected": false,
-            "text": "1000000000",
-            "value": "1000000000"
-          },
-          {
-            "selected": false,
-            "text": "10000000000",
-            "value": "10000000000"
-          },
-          {
-            "selected": true,
-            "text": "100000000000",
-            "value": "100000000000"
-          }
-        ],
-        "query": "100000, 1000000, 10000000, 100000000, 1000000000, 10000000000, 100000000000",
         "skipUrlSync": false,
         "type": "custom"
       },

--- a/dashboards/flow-analysis.json
+++ b/dashboards/flow-analysis.json
@@ -16,11 +16,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-<<<<<<< HEAD
-  "iteration": 1587436656061,
-=======
   "iteration": 1587496702022,
->>>>>>> 1.4.0
   "links": [],
   "panels": [
     {


### PR DESCRIPTION
This PR reverts the flow analysis to the version without the debugging dashboard filters and queries. It still maintains the Unique Count being used.
