### PR TITLE
Grafana 6.7.2 Other Flow Stats

### DIFF
--- a/dashboards/other-flow-stats.json
+++ b/dashboards/other-flow-stats.json
@@ -2,6 +2,7 @@
   "annotations": {
     "list": [
       {
+        "$$hashKey": "object:10",
         "builtIn": 1,
         "datasource": "-- Grafana --",
         "enable": true,
@@ -15,7 +16,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1582058414542,
+  "iteration": 1587580867591,
   "links": [],
   "panels": [
     {
@@ -208,6 +209,7 @@
       "custom_hover": " ",
       "cycleview": true,
       "dashboardselection": true,
+      "datasource": null,
       "gridPos": {
         "h": 2,
         "w": 2,
@@ -278,7 +280,6 @@
       "option_2": "netsagenavigation",
       "option_3": "plugin",
       "option_4": 123,
-      "options": {},
       "parsed_data": [
         {
           "avg": 362737.875739645,
@@ -386,6 +387,7 @@
     },
     {
       "content": "<center><h1><b>Other Flow Statistics</b></h1></center>\n<center>This dashboard provides a summary of flow information for science registry tagging, organizations, countries, protocols, ports, as well as volume and counts of flows. </center><center>All times are displayed in browser local time. </center>\n<!-- Global site tag (gtag.js) - Google Analytics -->\n<script async src=\"https://www.googletagmanager.com/gtag/js?id=UA-142763676-1\"></script>\n<script>\n  window.dataLayer = window.dataLayer || [];\n  function gtag(){dataLayer.push(arguments);}\n  gtag('js', new Date());\n\n  gtag('config', 'UA-142763676-1');\n</script>",
+      "datasource": null,
       "gridPos": {
         "h": 3,
         "w": 20,
@@ -395,7 +397,6 @@
       "id": 27,
       "links": [],
       "mode": "html",
-      "options": {},
       "title": "",
       "transparent": true,
       "type": "text"
@@ -406,9 +407,9 @@
       "colorPostfix": true,
       "colorValue": false,
       "colors": [
-        "rgb(5, 5, 5)",
-        "#FF9830",
-        "#FF9830"
+        "#FF780A",
+        "#FF780A",
+        "#FF780A"
       ],
       "datasource": "netsage",
       "format": "locale",
@@ -426,15 +427,17 @@
         "y": 3
       },
       "id": 29,
-      "interval": null,
+      "interval": "1h",
       "links": [],
       "mappingType": 1,
       "mappingTypes": [
         {
+          "$$hashKey": "object:175",
           "name": "value to text",
           "value": 1
         },
         {
+          "$$hashKey": "object:176",
           "name": "range to text",
           "value": 2
         }
@@ -442,7 +445,6 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
-      "options": {},
       "postfix": " Large flows observed",
       "postfixFontSize": "70%",
       "prefix": "",
@@ -465,6 +467,7 @@
         {
           "bucketAggs": [
             {
+              "$$hashKey": "object:114",
               "field": "start",
               "id": "2",
               "settings": {
@@ -477,6 +480,7 @@
           ],
           "metrics": [
             {
+              "$$hashKey": "object:112",
               "field": "meta.id.keyword",
               "id": "1",
               "meta": {},
@@ -489,13 +493,15 @@
           "timeField": "start"
         }
       ],
-      "thresholds": "",
+      "thresholds": "0,1",
+      "timeFrom": null,
       "title": "",
       "transparent": true,
       "type": "singlestat",
       "valueFontSize": "80%",
       "valueMaps": [
         {
+          "$$hashKey": "object:178",
           "op": "=",
           "text": "N/A",
           "value": "null"
@@ -513,6 +519,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
+      "datasource": null,
       "description": "",
       "format": "locale",
       "gauge": {
@@ -545,7 +552,6 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
-      "options": {},
       "postfix": "",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -610,7 +616,8 @@
       "valueName": "avg"
     },
     {
-      "content": "<br>\n<h4  style = 'font-weight:bold; color:#ef8e45'>Flows with only one end tagged in Science Registry</h4>\n",
+      "content": "<br>\n<h4  style = 'font-weight:bold; color:#FF780A'>Flows with only one end tagged in Science Registry</h4>\n",
+      "datasource": null,
       "gridPos": {
         "h": 2,
         "w": 7,
@@ -620,7 +627,6 @@
       "id": 3229,
       "links": [],
       "mode": "html",
-      "options": {},
       "timeFrom": null,
       "timeShift": null,
       "title": "",
@@ -637,6 +643,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
+      "datasource": null,
       "format": "locale",
       "gauge": {
         "maxValue": 100,
@@ -668,7 +675,6 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
-      "options": {},
       "postfix": "",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -732,7 +738,8 @@
       "valueName": "avg"
     },
     {
-      "content": "<br>\n<h4  style = 'font-weight:bold; color:#ef8e45'> Flows with both ends tagged in Science Registry</h4>\n",
+      "content": "<br>\n<h4  style = 'font-weight:bold; color:#FF780A'> Flows with both ends tagged in Science Registry</h4>\n",
+      "datasource": null,
       "gridPos": {
         "h": 2,
         "w": 7,
@@ -742,7 +749,6 @@
       "id": 3230,
       "links": [],
       "mode": "html",
-      "options": {},
       "timeFrom": null,
       "timeShift": null,
       "title": "",
@@ -759,6 +765,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
+      "datasource": null,
       "decimals": null,
       "format": "locale",
       "gauge": {
@@ -791,7 +798,6 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
-      "options": {},
       "postfix": "",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -855,7 +861,8 @@
       "valueName": "total"
     },
     {
-      "content": "<br>\n<h4  style = 'font-weight:bold; color:#ef8e45'>Source Organizations</h4>\n",
+      "content": "<br>\n<h4  style = 'font-weight:bold; color:#FF780A'>Source Organizations</h4>\n",
+      "datasource": null,
       "gridPos": {
         "h": 2,
         "w": 7,
@@ -865,7 +872,6 @@
       "id": 3231,
       "links": [],
       "mode": "html",
-      "options": {},
       "timeFrom": null,
       "timeShift": null,
       "title": "",
@@ -882,6 +888,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
+      "datasource": null,
       "format": "locale",
       "gauge": {
         "maxValue": 100,
@@ -913,7 +920,6 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
-      "options": {},
       "postfix": "",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -977,7 +983,8 @@
       "valueName": "total"
     },
     {
-      "content": "<br>\n<h4  style = 'font-weight:bold; color:#ef8e45'>Destination Organizations</h4>\n",
+      "content": "<br>\n<h4  style = 'font-weight:bold; color:#FF780A'>Destination Organizations</h4>\n",
+      "datasource": null,
       "gridPos": {
         "h": 2,
         "w": 7,
@@ -987,7 +994,6 @@
       "id": 3232,
       "links": [],
       "mode": "html",
-      "options": {},
       "timeFrom": null,
       "timeShift": null,
       "title": "",
@@ -1004,6 +1010,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
+      "datasource": null,
       "decimals": null,
       "description": "",
       "format": "locale",
@@ -1037,7 +1044,6 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
-      "options": {},
       "postfix": "",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -1101,7 +1107,8 @@
       "valueName": "total"
     },
     {
-      "content": "<br>\n<h4  style = 'font-weight:bold; color:#ef8e45'>Source AS Numbers</h4>\n",
+      "content": "<br>\n<h4  style = 'font-weight:bold; color:#FF780A'>Source AS Numbers</h4>\n",
+      "datasource": null,
       "gridPos": {
         "h": 2,
         "w": 7,
@@ -1111,7 +1118,6 @@
       "id": 3233,
       "links": [],
       "mode": "html",
-      "options": {},
       "timeFrom": null,
       "timeShift": null,
       "title": "",
@@ -1128,6 +1134,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
+      "datasource": null,
       "decimals": null,
       "format": "locale",
       "gauge": {
@@ -1160,7 +1167,6 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
-      "options": {},
       "postfix": "",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -1224,7 +1230,8 @@
       "valueName": "total"
     },
     {
-      "content": "<br>\n<h4  style = 'font-weight:bold; color:#ef8e45'>Destination AS numbers</h4>\n",
+      "content": "<br>\n<h4  style = 'font-weight:bold; color:#FF780A'>Destination AS numbers</h4>\n",
+      "datasource": null,
       "gridPos": {
         "h": 2,
         "w": 7,
@@ -1234,7 +1241,6 @@
       "id": 3234,
       "links": [],
       "mode": "html",
-      "options": {},
       "timeFrom": null,
       "timeShift": null,
       "title": "",
@@ -1251,6 +1257,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
+      "datasource": null,
       "description": "",
       "format": "none",
       "gauge": {
@@ -1283,7 +1290,6 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
-      "options": {},
       "postfix": "",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -1347,7 +1353,8 @@
       "valueName": "total"
     },
     {
-      "content": "<br>\n<h4  style = 'font-weight:bold; color:#ef8e45'>Source Country Codes</h4>\n",
+      "content": "<br>\n<h4  style = 'font-weight:bold; color:#FF780A'>Source Country Codes</h4>\n",
+      "datasource": null,
       "gridPos": {
         "h": 2,
         "w": 7,
@@ -1357,7 +1364,6 @@
       "id": 3235,
       "links": [],
       "mode": "html",
-      "options": {},
       "timeFrom": null,
       "timeShift": null,
       "title": "",
@@ -1374,6 +1380,7 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
+      "datasource": null,
       "format": "none",
       "gauge": {
         "maxValue": 100,
@@ -1405,7 +1412,6 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
-      "options": {},
       "postfix": "",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -1469,7 +1475,8 @@
       "valueName": "avg"
     },
     {
-      "content": "<br>\n<h4  style = 'font-weight:bold; color:#ef8e45'>Destination Country Codes</h4>\n",
+      "content": "<br>\n<h4  style = 'font-weight:bold; color:#FF780A'>Destination Country Codes</h4>\n",
+      "datasource": null,
       "gridPos": {
         "h": 2,
         "w": 7,
@@ -1479,7 +1486,6 @@
       "id": 3236,
       "links": [],
       "mode": "html",
-      "options": {},
       "timeFrom": null,
       "timeShift": null,
       "title": "",
@@ -1501,6 +1507,7 @@
         "x": 0,
         "y": 15
       },
+      "hiddenSeries": false,
       "id": 25,
       "legend": {
         "alignAsTable": true,
@@ -1627,6 +1634,7 @@
         "x": 8,
         "y": 15
       },
+      "hiddenSeries": false,
       "id": 22,
       "legend": {
         "alignAsTable": true,
@@ -1753,6 +1761,7 @@
         "x": 16,
         "y": 15
       },
+      "hiddenSeries": false,
       "id": 23,
       "legend": {
         "alignAsTable": true,
@@ -1869,7 +1878,7 @@
     {
       "columns": [],
       "datasource": "netsage",
-      "fontSize": "100%",
+      "fontSize": "90%",
       "gridPos": {
         "h": 11,
         "w": 24,
@@ -1879,7 +1888,6 @@
       "hideTimeOverride": false,
       "id": 19,
       "links": [],
-      "options": {},
       "pageSize": 10,
       "scroll": false,
       "showHeader": true,
@@ -1889,7 +1897,9 @@
       },
       "styles": [
         {
+          "$$hashKey": "object:329",
           "alias": "Link",
+          "align": "auto",
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
           "link": false,
           "linkTargetBlank": true,
@@ -1900,7 +1910,9 @@
           "unit": "bits"
         },
         {
+          "$$hashKey": "object:330",
           "alias": "# Flows",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -1915,7 +1927,9 @@
           "unit": "short"
         },
         {
+          "$$hashKey": "object:331",
           "alias": "Total Volume",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -1930,7 +1944,9 @@
           "unit": "decbytes"
         },
         {
+          "$$hashKey": "object:332",
           "alias": "Total Packets",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -1945,7 +1961,9 @@
           "unit": "short"
         },
         {
+          "$$hashKey": "object:333",
           "alias": "Largest Flow",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -1960,7 +1978,9 @@
           "unit": "decbytes"
         },
         {
+          "$$hashKey": "object:334",
           "alias": "Fastest Flow",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -1975,7 +1995,9 @@
           "unit": "bps"
         },
         {
+          "$$hashKey": "object:335",
           "alias": "Sum",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -1995,6 +2017,7 @@
         {
           "bucketAggs": [
             {
+              "$$hashKey": "object:220",
               "fake": true,
               "field": "meta.sensor_id.keyword",
               "id": "3",
@@ -2010,6 +2033,7 @@
           "dsType": "elasticsearch",
           "metrics": [
             {
+              "$$hashKey": "object:212",
               "field": "values.num_bits",
               "id": "1",
               "inlineScript": "_value/8",
@@ -2022,6 +2046,7 @@
               "type": "sum"
             },
             {
+              "$$hashKey": "object:213",
               "field": "values.num_bits",
               "id": "5",
               "inlineScript": "_value / 8",
@@ -2034,6 +2059,7 @@
               "type": "max"
             },
             {
+              "$$hashKey": "object:214",
               "field": "values.bits_per_second",
               "id": "6",
               "meta": {},
@@ -2041,6 +2067,7 @@
               "type": "max"
             },
             {
+              "$$hashKey": "object:215",
               "field": "meta.id.keyword",
               "id": "7",
               "meta": {},
@@ -2073,6 +2100,7 @@
         "x": 0,
         "y": 34
       },
+      "hiddenSeries": false,
       "id": 24,
       "legend": {
         "alignAsTable": true,
@@ -2182,6 +2210,7 @@
     },
     {
       "content": "<div> If you have any questions, concerns, or other issues, feel free to contact us at <a href=\"mailto:netsage@iu.edu\">netsage@iu.edu</a>.  Thanks!  <img style=\"margin-left:10px\" src=\"https://www.nsf.gov/images/logos/NSF_4-Color_bitmap_Logo.png\" width=50 height=50> <a href=\"https://www.nsf.gov/awardsearch/showAward?AWD_ID=1540933\"> NSF GRANT 1540933 </a> </img> <span style=\"float:right; position:relative; top:15px\"> To Review the NetSage Data Policy <a href=\"http://www.netsage.global/home/netsage-privacy-policy\"> click here </a> </div>",
+      "datasource": null,
       "gridPos": {
         "h": 3,
         "w": 24,
@@ -2191,14 +2220,13 @@
       "id": 31,
       "links": [],
       "mode": "html",
-      "options": {},
       "title": "",
       "transparent": true,
       "type": "text"
     }
   ],
   "refresh": false,
-  "schemaVersion": 19,
+  "schemaVersion": 22,
   "style": "dark",
   "tags": [
     "flow",
@@ -2218,6 +2246,7 @@
         "definition": "{\"find\":\"terms\", \"field\":\"meta.sensor_id.keyword\", \"query\":\"-meta.sensor_id:*cenic* AND -meta.sensor_id:*pacificwave*\"}",
         "hide": 0,
         "includeAll": true,
+        "index": -1,
         "label": "Sensor",
         "multi": true,
         "name": "sensors",
@@ -2267,5 +2296,8 @@
   },
   "timezone": "",
   "title": "Other Flow Stats",
-  "uid": "CJC1FFhmz"
+  "uid": "CJC1FFhmz",
+  "variables": {
+    "list": []
+  }
 }


### PR DESCRIPTION
This has the Grafana 6.7.2 changes for other flow stats. (Note: My other dashboard was Science Discipline patterns and requires no changes). I updated the following:

- Updated the single stat pane on the top to use default orange
- All other single stats actually had text panels next to them, so updated those text panels to use the same default orange
- The table at the bottom was updated with text size set to 90%

All the other stuff in the diff is usual grafana noise. 