### PR TITLE
Grafana 7 update for Other Stats dashboard

### DIFF
--- a/dashboards/General/other-flow-stats.json
+++ b/dashboards/General/other-flow-stats.json
@@ -16,7 +16,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1591823863174,
+  "iteration": 1594395188001,
   "links": [],
   "panels": [
     {
@@ -216,6 +216,7 @@
         },
         "overrides": []
       },
+      "grafanafavorites": true,
       "gridPos": {
         "h": 2,
         "w": 2,
@@ -354,6 +355,7 @@
       "sharescreen": true,
       "sideLogoPath": "https://portal.netsage.global/netsage-header-logo.png",
       "sidebar": true,
+      "tablefilters": true,
       "targets": [
         {
           "bucketAggs": [
@@ -420,7 +422,6 @@
       "fieldConfig": {
         "defaults": {
           "custom": {},
-          "displayName": "Large flows observed",
           "mappings": [
             {
               "$$hashKey": "object:178",
@@ -436,7 +437,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "blue",
+                "color": "light-blue",
                 "value": null
               }
             ]
@@ -473,7 +474,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.0.5",
       "targets": [
         {
           "bucketAggs": [
@@ -505,7 +506,7 @@
         }
       ],
       "timeFrom": null,
-      "title": "",
+      "title": "Large Flows Observed",
       "transparent": true,
       "type": "stat"
     },
@@ -529,7 +530,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "blue",
+                "color": "light-blue",
                 "value": null
               }
             ]
@@ -566,7 +567,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.0.5",
       "targets": [
         {
           "bucketAggs": [
@@ -733,7 +734,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "blue",
+                "color": "light-blue",
                 "value": null
               }
             ]
@@ -770,7 +771,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.0.5",
       "targets": [
         {
           "panelId": 4,
@@ -875,7 +876,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "blue",
+                "color": "light-blue",
                 "value": null
               }
             ]
@@ -912,7 +913,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.0.5",
       "targets": [
         {
           "panelId": 4,
@@ -1017,7 +1018,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "blue",
+                "color": "light-blue",
                 "value": null
               }
             ]
@@ -1054,7 +1055,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.0.5",
       "targets": [
         {
           "panelId": 4,
@@ -1161,7 +1162,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "blue",
+                "color": "light-blue",
                 "value": null
               }
             ]
@@ -1198,7 +1199,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.0.5",
       "targets": [
         {
           "panelId": 4,
@@ -1303,7 +1304,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "blue",
+                "color": "light-blue",
                 "value": null
               }
             ]
@@ -1340,7 +1341,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.0.5",
       "targets": [
         {
           "panelId": 4,
@@ -1446,7 +1447,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "blue",
+                "color": "light-blue",
                 "value": null
               }
             ]
@@ -1483,7 +1484,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.0.5",
       "targets": [
         {
           "alias": "",
@@ -1591,7 +1592,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "blue",
+                "color": "light-blue",
                 "value": null
               }
             ]
@@ -1628,7 +1629,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.0.5",
       "targets": [
         {
           "bucketAggs": [
@@ -2229,7 +2230,7 @@
       "options": {
         "showHeader": true
       },
-      "pluginVersion": "7.0.3",
+      "pluginVersion": "7.0.5",
       "targets": [
         {
           "bucketAggs": [


### PR DESCRIPTION
This updates the Other Stats dashboard to Grafana 7. Most of work was already done at hackathon, so not much to do on this one. Following changes were needed;

- Updated single stats to correct blue
- Updated single stats at top that counts all large flow to use a title in stead of a (prefix) description

A couple other notes:

- Sensor table was already converted and followed spec so no changes needed
- Many of the  single stats have text panels next to them that act as prefixes. I left this as-is since this dashboard has always been a special snowflake in that regard and I don't think we want to change the layout for this release. 