### PR TITLE
adjusted col. widths in flow-analysis

### DIFF
--- a/dashboards/General/flow-analysis.json
+++ b/dashboards/General/flow-analysis.json
@@ -16,7 +16,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1594135720477,
+  "iteration": 1594941217868,
   "links": [],
   "panels": [
     {
@@ -679,6 +679,10 @@
               {
                 "id": "unit",
                 "value": "locale"
+              },
+              {
+                "id": "custom.width",
+                "value": 100
               }
             ]
           },
@@ -691,6 +695,10 @@
               {
                 "id": "unit",
                 "value": "bps"
+              },
+              {
+                "id": "custom.width",
+                "value": 115
               }
             ]
           },
@@ -703,6 +711,10 @@
               {
                 "id": "unit",
                 "value": "bps"
+              },
+              {
+                "id": "custom.width",
+                "value": 115
               }
             ]
           },
@@ -743,6 +755,30 @@
               {
                 "id": "custom.align",
                 "value": "left"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Total Vol."
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 100
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Largest Flow"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 100
               }
             ]
           }
@@ -969,6 +1005,10 @@
               {
                 "id": "unit",
                 "value": "locale"
+              },
+              {
+                "id": "custom.width",
+                "value": 200
               }
             ]
           },
@@ -989,6 +1029,18 @@
               {
                 "id": "custom.align",
                 "value": "left"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Largest Flow"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 200
               }
             ]
           }
@@ -1112,6 +1164,10 @@
               {
                 "id": "unit",
                 "value": "locale"
+              },
+              {
+                "id": "custom.width",
+                "value": 200
               }
             ]
           },
@@ -1148,6 +1204,18 @@
               {
                 "id": "custom.align",
                 "value": "left"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Average"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 200
               }
             ]
           }
@@ -1308,6 +1376,10 @@
               {
                 "id": "unit",
                 "value": "locale"
+              },
+              {
+                "id": "custom.width",
+                "value": 200
               }
             ]
           },
@@ -1344,6 +1416,18 @@
               {
                 "id": "custom.align",
                 "value": "left"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Largest Flow"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 200
               }
             ]
           }
@@ -1467,6 +1551,10 @@
               {
                 "id": "unit",
                 "value": "locale"
+              },
+              {
+                "id": "custom.width",
+                "value": 200
               }
             ]
           },
@@ -1503,6 +1591,18 @@
               {
                 "id": "custom.align",
                 "value": "left"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Average"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 200
               }
             ]
           }
@@ -1644,6 +1744,10 @@
               {
                 "id": "unit",
                 "value": "dateTimeAsIso"
+              },
+              {
+                "id": "custom.width",
+                "value": 200
               }
             ]
           },
@@ -1656,6 +1760,10 @@
               {
                 "id": "unit",
                 "value": "bps"
+              },
+              {
+                "id": "custom.width",
+                "value": 115
               }
             ]
           },
@@ -1668,6 +1776,10 @@
               {
                 "id": "unit",
                 "value": "dthms"
+              },
+              {
+                "id": "custom.width",
+                "value": 100
               }
             ]
           },
@@ -1688,6 +1800,10 @@
               {
                 "id": "custom.align",
                 "value": "right"
+              },
+              {
+                "id": "custom.width",
+                "value": 100
               }
             ]
           },
@@ -1704,6 +1820,10 @@
               {
                 "id": "custom.align",
                 "value": "right"
+              },
+              {
+                "id": "custom.width",
+                "value": 100
               }
             ]
           },
@@ -1744,6 +1864,42 @@
               {
                 "id": "custom.align",
                 "value": "left"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Source Subnet"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 150
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Destination Subnet"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 150
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Total Vol."
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 100
               }
             ]
           }


### PR DESCRIPTION
In the tables with many columns, I set numeric column widths to 100 or 115 and subnet columns to 150.
For tables with only 4 columns, I set numeric ones to 200, as the best compromise between looking good if window is too small or too big. 
In Indiv. Flows table, I set timestamp width to 200.
Change if you don't like it! 
