### PR TITLE
Fixes for Individualizing by Country and Bandwidth patterns

### DIFF
--- a/dashboards/General/bandwidth-patterns.json
+++ b/dashboards/General/bandwidth-patterns.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1594323465027,
+  "iteration": 1597844239736,
   "links": [],
   "panels": [
     {
@@ -419,7 +419,7 @@
       "type": "text"
     },
     {
-      "collapsed": true,
+      "collapsed": false,
       "datasource": null,
       "gridPos": {
         "h": 1,
@@ -428,396 +428,398 @@
         "y": 4
       },
       "id": 3,
-      "panels": [
-        {
-          "datasource": "Netsage TSDS",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {
-                "calculation": "mean",
-                "colorPalette": "interpolateBlues",
-                "colorSpace": "rgb",
-                "groupBy": 60
-              },
-              "decimals": 1,
-              "unit": "bps"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 10,
-            "w": 24,
-            "x": 0,
-            "y": 5
-          },
-          "id": 4,
-          "links": [],
-          "options": {
-            "from": "0",
-            "showLegend": false,
-            "to": "0"
-          },
-          "repeatDirection": "h",
-          "targets": [
-            {
-              "aggregate_all": false,
-              "aggregator": [
-                "average"
-              ],
-              "bucket": [],
-              "bucketAggs": [
-                {
-                  "field": "start",
-                  "id": "2",
-                  "settings": {
-                    "interval": "auto",
-                    "min_doc_count": 0,
-                    "trimEdges": 0
-                  },
-                  "type": "date_histogram"
-                }
-              ],
-              "combineAllBy": "nothing",
-              "condition": [],
-              "dateFormat": "",
-              "displayFormat": "series",
-              "drillDown": [],
-              "drillDownAlias": "",
-              "drillDownValue": [],
-              "dsType": "elasticsearch",
-              "func": [
-                {
-                  "alias": "",
-                  "bucket": "",
-                  "expanded": false,
-                  "method": "average",
-                  "operation": "",
-                  "percentile": "85",
-                  "root": true,
-                  "target": "input",
-                  "template": "",
-                  "title": "Aggregate",
-                  "type": "Aggregate",
-                  "wrapper": []
-                }
-              ],
-              "groupby_field": " ",
-              "inlineGroupOperator": [
-                [
-                  "",
-                  "and"
-                ]
-              ],
-              "metricValueAliasMappings": {},
-              "metricValueAliases": [
-                ""
-              ],
-              "metricValues_array": [
-                "$data_direction"
-              ],
-              "metric_array": [
-                "link_name"
-              ],
-              "metrics": [
-                {
-                  "field": "select field",
-                  "id": "1",
-                  "type": "count"
-                }
-              ],
-              "orderby_field": "",
-              "outerGroupOperator": [
-                ""
-              ],
-              "percentileValue": [
-                ""
-              ],
-              "rawQuery": true,
-              "refId": "A",
-              "series": "interface",
-              "target": "get node, aggregate(values.$data_direction,3600, $statistics) between ($START, $END) from interface where (node =  \"mct01.miami.ampath.net\" or node = \"mct02.miami.ampath.net\")",
-              "target_alias": "",
-              "templateVariableValue": [
-                ""
-              ],
-              "timeField": "start",
-              "type": "timeserie",
-              "whereClauseGroup": [
-                [
-                  {
-                    "left": "link_name",
-                    "op": "=",
-                    "right": "$links"
-                  }
-                ]
-              ]
-            }
-          ],
-          "timeFrom": null,
-          "title": "Amlight Exchange Point",
-          "type": "marcusolsson-hourly-heatmap-panel"
-        },
-        {
-          "datasource": "Netsage TSDS",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {
-                "calculation": "mean",
-                "colorPalette": "interpolateBlues",
-                "colorSpace": "rgb",
-                "groupBy": 60
-              },
-              "decimals": 1,
-              "unit": "bps"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 10,
-            "w": 24,
-            "x": 0,
-            "y": 15
-          },
-          "id": 5,
-          "links": [],
-          "options": {
-            "from": "0",
-            "showLegend": false,
-            "to": "0"
-          },
-          "repeatDirection": "h",
-          "targets": [
-            {
-              "aggregate_all": false,
-              "aggregator": [
-                "average"
-              ],
-              "bucket": [],
-              "bucketAggs": [
-                {
-                  "field": "start",
-                  "id": "2",
-                  "settings": {
-                    "interval": "auto",
-                    "min_doc_count": 0,
-                    "trimEdges": 0
-                  },
-                  "type": "date_histogram"
-                }
-              ],
-              "combineAllBy": "nothing",
-              "condition": [],
-              "dateFormat": "",
-              "displayFormat": "series",
-              "drillDown": [],
-              "drillDownAlias": "",
-              "drillDownValue": [],
-              "dsType": "elasticsearch",
-              "func": [
-                {
-                  "alias": "",
-                  "bucket": "",
-                  "expanded": false,
-                  "method": "average",
-                  "operation": "",
-                  "percentile": "85",
-                  "root": true,
-                  "target": "input",
-                  "template": "",
-                  "title": "Aggregate",
-                  "type": "Aggregate",
-                  "wrapper": []
-                }
-              ],
-              "groupby_field": " ",
-              "inlineGroupOperator": [
-                [
-                  "",
-                  "and"
-                ]
-              ],
-              "metricValueAliasMappings": {},
-              "metricValueAliases": [
-                ""
-              ],
-              "metricValues_array": [
-                "$data_direction"
-              ],
-              "metric_array": [
-                "link_name"
-              ],
-              "metrics": [
-                {
-                  "field": "select field",
-                  "id": "1",
-                  "type": "count"
-                }
-              ],
-              "orderby_field": "",
-              "outerGroupOperator": [
-                ""
-              ],
-              "percentileValue": [
-                ""
-              ],
-              "rawQuery": true,
-              "refId": "A",
-              "series": "interface",
-              "target": "get node, intf, aggregate(values.$data_direction, 3600, $statistics) between ($START, $END) from interface where (node = \"wrn-albu-sw-3.cenic.net\" and intf = \"ethernet5/1\") or (node = \"snvl2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet6/15\") or (node = \"wrn-albu-sw-4.cenic.net\" and intf = \"ethernet3/1\") or (node = \"snvl2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet8/3\") or (node = \"snvl2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet8/10\") or (node = \"wrn-albu-sw-3.cenic.net\" and intf = \"ethernet7/1\") or (node = \"losa3-pw-sw-1.cenic.net\" and intf = \"ethernet4/1\") or (node = \"wrn-denv-sw-4.cenic.net\" and intf = \"ethernet7/2\") or (node = \"losa2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet15/2\") or (node = \"snvl2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet1/1\") or (node = \"losa2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet4/1\") or (node = \"losa2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet15/8\") or (node = \"losa2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet7/7\") or (node = \"snvl2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet3/1\") or (node = \"wrn-elpa-sw-1.cenic.net\" and intf = \"ethernet1/1\") or (node = \"losa3-pw-sw-1.cenic.net\" and intf = \"ethernet7/1\") or (node = \"snvl2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet7/2\") or (node = \"losa2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet15/5\") or (node = \"wrn-elpa-sw-1.cenic.net\" and intf = \"ethernet5/1\") or (node = \"losa2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet1/2\") or (node = \"losa2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet16/5\") or (node = \"wrn-denv-sw-3.cenic.net\" and intf = \"ethernet7/1\") or (node = \"snvl2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet6/20\") or (node = \"losa2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet13/1\") or (node = \"snvl2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet8/5\") or (node = \"losa2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet15/6\") or (node = \"wrn-denv-sw-4.cenic.net\" and intf = \"ethernet7/1\") or (node = \"wrn-albu-sw-4.cenic.net\" and intf = \"ethernet5/1\") or (node = \"losa2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet3/2\") or (node = \"wrn-denv-sw-4.cenic.net\" and intf = \"ethernet1/1\") or (node = \"wrn-denv-sw-3.cenic.net\" and intf = \"ethernet1/2\") or (node = \"losa2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet1/1\") or (node = \"losa3-pw-sw-1.cenic.net\" and intf = \"ethernet7/2\") or (node = \"losa2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet15/7\") or (node = \"snvl2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet8/9\") or (node = \"losa2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet16/7\") or (node = \"losa2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet6/2\") or (node = \"snvl2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet3/2\") or (node = \"wrn-denv-sw-4.cenic.net\" and intf = \"ethernet5/2\") or (node = \"losa2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet4/2\") or (node = \"losa2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet5/2\") or (node = \"losa2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet9/1\") or (node = \"wrn-denv-sw-3.cenic.net\" and intf = \"ethernet5/2\")",
-              "target_alias": "",
-              "templateVariableValue": [
-                ""
-              ],
-              "timeField": "start",
-              "type": "timeserie",
-              "whereClauseGroup": [
-                [
-                  {
-                    "left": "link_name",
-                    "op": "=",
-                    "right": "$links"
-                  }
-                ]
-              ]
-            }
-          ],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Pacific Wave Exchange Point",
-          "type": "marcusolsson-hourly-heatmap-panel"
-        },
-        {
-          "datasource": "Netsage TSDS",
-          "fieldConfig": {
-            "defaults": {
-              "custom": {
-                "calculation": "mean",
-                "colorPalette": "interpolateBlues",
-                "colorSpace": "rgb",
-                "groupBy": 60
-              },
-              "decimals": 1,
-              "unit": "bps"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 10,
-            "w": 24,
-            "x": 0,
-            "y": 25
-          },
-          "id": 6,
-          "links": [],
-          "options": {
-            "from": "0",
-            "showLegend": false,
-            "to": "0"
-          },
-          "repeat": null,
-          "repeatDirection": "h",
-          "targets": [
-            {
-              "aggregate_all": false,
-              "aggregator": [
-                "average"
-              ],
-              "bucket": [],
-              "bucketAggs": [
-                {
-                  "field": "start",
-                  "id": "2",
-                  "settings": {
-                    "interval": "auto",
-                    "min_doc_count": 0,
-                    "trimEdges": 0
-                  },
-                  "type": "date_histogram"
-                }
-              ],
-              "combineAllBy": "nothing",
-              "condition": [],
-              "dateFormat": "",
-              "displayFormat": "series",
-              "drillDown": [],
-              "drillDownAlias": "",
-              "drillDownValue": [],
-              "dsType": "elasticsearch",
-              "func": [
-                {
-                  "alias": "",
-                  "bucket": "",
-                  "expanded": false,
-                  "method": "average",
-                  "operation": "",
-                  "percentile": "85",
-                  "root": true,
-                  "target": "input",
-                  "template": "",
-                  "title": "Aggregate",
-                  "type": "Aggregate",
-                  "wrapper": []
-                }
-              ],
-              "groupby_field": " ",
-              "inlineGroupOperator": [
-                [
-                  "",
-                  "and"
-                ]
-              ],
-              "metricValueAliasMappings": {},
-              "metricValueAliases": [
-                ""
-              ],
-              "metricValues_array": [
-                "$data_direction"
-              ],
-              "metric_array": [
-                "link_name"
-              ],
-              "metrics": [
-                {
-                  "field": "select field",
-                  "id": "1",
-                  "type": "count"
-                }
-              ],
-              "orderby_field": "",
-              "outerGroupOperator": [
-                ""
-              ],
-              "percentileValue": [
-                ""
-              ],
-              "rawQuery": true,
-              "refId": "A",
-              "series": "interface",
-              "target": "get node, intf, aggregate(values.$data_direction, 3600, $statistics) between ($START, $END) from interface where (node = \"8700.mren.org\" and intf in (\"10/2\",\"4/6\",\"6/6\",\"1/6\",\"5/3\",\"6/3\",\"2/5\",\"4/3\",\"2/3\",\"9/2\")) or (node = \"ex9208.sl.startap.net\" and intf in (\"xe-0/1/2\",\"ae2\",\"xe-0/3/2\",\"xe-0/2/2\",\"ge-5/0/2\",\"xe-0/1/0\"))",
-              "target_alias": "",
-              "templateVariableValue": [
-                ""
-              ],
-              "timeField": "start",
-              "type": "timeserie",
-              "whereClauseGroup": [
-                [
-                  {
-                    "left": "link_name",
-                    "op": "=",
-                    "right": "$links"
-                  }
-                ]
-              ]
-            }
-          ],
-          "timeFrom": null,
-          "title": "Starlight Exchange Point",
-          "type": "marcusolsson-hourly-heatmap-panel"
-        }
-      ],
+      "panels": [],
       "title": "Exchange Points",
       "type": "row"
+    },
+    {
+      "datasource": "Netsage TSDS",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "calculation": "mean",
+            "colorPalette": "interpolateBlues",
+            "colorSpace": "rgb",
+            "groupBy": 60,
+            "invertPalette": false
+          },
+          "decimals": 1,
+          "unit": "bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 4,
+      "links": [],
+      "options": {
+        "from": "0",
+        "showLegend": false,
+        "to": "0"
+      },
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "aggregate_all": false,
+          "aggregator": [
+            "average"
+          ],
+          "bucket": [],
+          "bucketAggs": [
+            {
+              "field": "start",
+              "id": "2",
+              "settings": {
+                "interval": "auto",
+                "min_doc_count": 0,
+                "trimEdges": 0
+              },
+              "type": "date_histogram"
+            }
+          ],
+          "combineAllBy": "nothing",
+          "condition": [],
+          "dateFormat": "",
+          "displayFormat": "series",
+          "drillDown": [],
+          "drillDownAlias": "",
+          "drillDownValue": [],
+          "dsType": "elasticsearch",
+          "func": [
+            {
+              "alias": "",
+              "bucket": "",
+              "expanded": false,
+              "method": "average",
+              "operation": "",
+              "percentile": "85",
+              "root": true,
+              "target": "input",
+              "template": "",
+              "title": "Aggregate",
+              "type": "Aggregate",
+              "wrapper": []
+            }
+          ],
+          "groupby_field": " ",
+          "inlineGroupOperator": [
+            [
+              "",
+              "and"
+            ]
+          ],
+          "metricValueAliasMappings": {},
+          "metricValueAliases": [
+            ""
+          ],
+          "metricValues_array": [
+            "$data_direction"
+          ],
+          "metric_array": [
+            "link_name"
+          ],
+          "metrics": [
+            {
+              "field": "select field",
+              "id": "1",
+              "type": "count"
+            }
+          ],
+          "orderby_field": "",
+          "outerGroupOperator": [
+            ""
+          ],
+          "percentileValue": [
+            ""
+          ],
+          "rawQuery": true,
+          "refId": "A",
+          "series": "interface",
+          "target": "get node, aggregate(values.$data_direction,3600, $statistics) between ($START, $END) from interface where (node =  \"mct01.miami.ampath.net\" or node = \"mct02.miami.ampath.net\")",
+          "target_alias": "",
+          "templateVariableValue": [
+            ""
+          ],
+          "timeField": "start",
+          "type": "timeserie",
+          "whereClauseGroup": [
+            [
+              {
+                "left": "link_name",
+                "op": "=",
+                "right": "$links"
+              }
+            ]
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "title": "Amlight Exchange Point",
+      "type": "marcusolsson-hourly-heatmap-panel"
+    },
+    {
+      "datasource": "Netsage TSDS",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "calculation": "mean",
+            "colorPalette": "interpolateBlues",
+            "colorSpace": "rgb",
+            "groupBy": 60,
+            "invertPalette": false
+          },
+          "decimals": 1,
+          "unit": "bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      },
+      "id": 5,
+      "links": [],
+      "options": {
+        "from": "0",
+        "showLegend": false,
+        "to": "0"
+      },
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "aggregate_all": false,
+          "aggregator": [
+            "average"
+          ],
+          "bucket": [],
+          "bucketAggs": [
+            {
+              "field": "start",
+              "id": "2",
+              "settings": {
+                "interval": "auto",
+                "min_doc_count": 0,
+                "trimEdges": 0
+              },
+              "type": "date_histogram"
+            }
+          ],
+          "combineAllBy": "nothing",
+          "condition": [],
+          "dateFormat": "",
+          "displayFormat": "series",
+          "drillDown": [],
+          "drillDownAlias": "",
+          "drillDownValue": [],
+          "dsType": "elasticsearch",
+          "func": [
+            {
+              "alias": "",
+              "bucket": "",
+              "expanded": false,
+              "method": "average",
+              "operation": "",
+              "percentile": "85",
+              "root": true,
+              "target": "input",
+              "template": "",
+              "title": "Aggregate",
+              "type": "Aggregate",
+              "wrapper": []
+            }
+          ],
+          "groupby_field": " ",
+          "inlineGroupOperator": [
+            [
+              "",
+              "and"
+            ]
+          ],
+          "metricValueAliasMappings": {},
+          "metricValueAliases": [
+            ""
+          ],
+          "metricValues_array": [
+            "$data_direction"
+          ],
+          "metric_array": [
+            "link_name"
+          ],
+          "metrics": [
+            {
+              "field": "select field",
+              "id": "1",
+              "type": "count"
+            }
+          ],
+          "orderby_field": "",
+          "outerGroupOperator": [
+            ""
+          ],
+          "percentileValue": [
+            ""
+          ],
+          "rawQuery": true,
+          "refId": "A",
+          "series": "interface",
+          "target": "get node, intf, aggregate(values.$data_direction, 3600, $statistics) between ($START, $END) from interface where (node = \"wrn-albu-sw-3.cenic.net\" and intf = \"ethernet5/1\") or (node = \"snvl2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet6/15\") or (node = \"wrn-albu-sw-4.cenic.net\" and intf = \"ethernet3/1\") or (node = \"snvl2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet8/3\") or (node = \"snvl2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet8/10\") or (node = \"wrn-albu-sw-3.cenic.net\" and intf = \"ethernet7/1\") or (node = \"losa3-pw-sw-1.cenic.net\" and intf = \"ethernet4/1\") or (node = \"wrn-denv-sw-4.cenic.net\" and intf = \"ethernet7/2\") or (node = \"losa2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet15/2\") or (node = \"snvl2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet1/1\") or (node = \"losa2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet4/1\") or (node = \"losa2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet15/8\") or (node = \"losa2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet7/7\") or (node = \"snvl2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet3/1\") or (node = \"wrn-elpa-sw-1.cenic.net\" and intf = \"ethernet1/1\") or (node = \"losa3-pw-sw-1.cenic.net\" and intf = \"ethernet7/1\") or (node = \"snvl2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet7/2\") or (node = \"losa2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet15/5\") or (node = \"wrn-elpa-sw-1.cenic.net\" and intf = \"ethernet5/1\") or (node = \"losa2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet1/2\") or (node = \"losa2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet16/5\") or (node = \"wrn-denv-sw-3.cenic.net\" and intf = \"ethernet7/1\") or (node = \"snvl2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet6/20\") or (node = \"losa2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet13/1\") or (node = \"snvl2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet8/5\") or (node = \"losa2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet15/6\") or (node = \"wrn-denv-sw-4.cenic.net\" and intf = \"ethernet7/1\") or (node = \"wrn-albu-sw-4.cenic.net\" and intf = \"ethernet5/1\") or (node = \"losa2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet3/2\") or (node = \"wrn-denv-sw-4.cenic.net\" and intf = \"ethernet1/1\") or (node = \"wrn-denv-sw-3.cenic.net\" and intf = \"ethernet1/2\") or (node = \"losa2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet1/1\") or (node = \"losa3-pw-sw-1.cenic.net\" and intf = \"ethernet7/2\") or (node = \"losa2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet15/7\") or (node = \"snvl2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet8/9\") or (node = \"losa2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet16/7\") or (node = \"losa2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet6/2\") or (node = \"snvl2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet3/2\") or (node = \"wrn-denv-sw-4.cenic.net\" and intf = \"ethernet5/2\") or (node = \"losa2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet4/2\") or (node = \"losa2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet5/2\") or (node = \"losa2-pw-sw-1-mgmt-2.cenic.net\" and intf = \"ethernet9/1\") or (node = \"wrn-denv-sw-3.cenic.net\" and intf = \"ethernet5/2\")",
+          "target_alias": "",
+          "templateVariableValue": [
+            ""
+          ],
+          "timeField": "start",
+          "type": "timeserie",
+          "whereClauseGroup": [
+            [
+              {
+                "left": "link_name",
+                "op": "=",
+                "right": "$links"
+              }
+            ]
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Pacific Wave Exchange Point",
+      "type": "marcusolsson-hourly-heatmap-panel"
+    },
+    {
+      "datasource": "Netsage TSDS",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "calculation": "mean",
+            "colorPalette": "interpolateBlues",
+            "colorSpace": "rgb",
+            "groupBy": 60,
+            "invertPalette": false
+          },
+          "decimals": 1,
+          "unit": "bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 25
+      },
+      "id": 6,
+      "links": [],
+      "options": {
+        "from": "0",
+        "showLegend": false,
+        "to": "0"
+      },
+      "repeat": null,
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "aggregate_all": false,
+          "aggregator": [
+            "average"
+          ],
+          "bucket": [],
+          "bucketAggs": [
+            {
+              "field": "start",
+              "id": "2",
+              "settings": {
+                "interval": "auto",
+                "min_doc_count": 0,
+                "trimEdges": 0
+              },
+              "type": "date_histogram"
+            }
+          ],
+          "combineAllBy": "nothing",
+          "condition": [],
+          "dateFormat": "",
+          "displayFormat": "series",
+          "drillDown": [],
+          "drillDownAlias": "",
+          "drillDownValue": [],
+          "dsType": "elasticsearch",
+          "func": [
+            {
+              "alias": "",
+              "bucket": "",
+              "expanded": false,
+              "method": "average",
+              "operation": "",
+              "percentile": "85",
+              "root": true,
+              "target": "input",
+              "template": "",
+              "title": "Aggregate",
+              "type": "Aggregate",
+              "wrapper": []
+            }
+          ],
+          "groupby_field": " ",
+          "inlineGroupOperator": [
+            [
+              "",
+              "and"
+            ]
+          ],
+          "metricValueAliasMappings": {},
+          "metricValueAliases": [
+            ""
+          ],
+          "metricValues_array": [
+            "$data_direction"
+          ],
+          "metric_array": [
+            "link_name"
+          ],
+          "metrics": [
+            {
+              "field": "select field",
+              "id": "1",
+              "type": "count"
+            }
+          ],
+          "orderby_field": "",
+          "outerGroupOperator": [
+            ""
+          ],
+          "percentileValue": [
+            ""
+          ],
+          "rawQuery": true,
+          "refId": "A",
+          "series": "interface",
+          "target": "get node, intf, aggregate(values.$data_direction, 3600, $statistics) between ($START, $END) from interface where (node = \"8700.mren.org\" and intf in (\"10/2\",\"4/6\",\"6/6\",\"1/6\",\"5/3\",\"6/3\",\"2/5\",\"4/3\",\"2/3\",\"9/2\")) or (node = \"ex9208.sl.startap.net\" and intf in (\"xe-0/1/2\",\"ae2\",\"xe-0/3/2\",\"xe-0/2/2\",\"ge-5/0/2\",\"xe-0/1/0\"))",
+          "target_alias": "",
+          "templateVariableValue": [
+            ""
+          ],
+          "timeField": "start",
+          "type": "timeserie",
+          "whereClauseGroup": [
+            [
+              {
+                "left": "link_name",
+                "op": "=",
+                "right": "$links"
+              }
+            ]
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "title": "Starlight Exchange Point",
+      "type": "marcusolsson-hourly-heatmap-panel"
     },
     {
       "collapsed": false,
@@ -826,7 +828,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 5
+        "y": 35
       },
       "id": 7,
       "panels": [],
@@ -841,7 +843,8 @@
             "calculation": "mean",
             "colorPalette": "interpolateBlues",
             "colorSpace": "rgb",
-            "groupBy": 60
+            "groupBy": 60,
+            "invertPalette": false
           },
           "decimals": 1,
           "unit": "bps"
@@ -852,7 +855,7 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 6
+        "y": 36
       },
       "id": 8,
       "links": [],
@@ -977,7 +980,8 @@
             "calculation": "mean",
             "colorPalette": "interpolateBlues",
             "colorSpace": "rgb",
-            "groupBy": 60
+            "groupBy": 60,
+            "invertPalette": false
           },
           "decimals": 1,
           "unit": "bps"
@@ -986,146 +990,9 @@
       },
       "gridPos": {
         "h": 10,
-        "w": 6,
+        "w": 24,
         "x": 0,
-        "y": 16
-      },
-      "id": 13,
-      "links": [],
-      "options": {
-        "from": "0",
-        "showLegend": false,
-        "to": "0"
-      },
-      "repeat": null,
-      "repeatIteration": 1594323465027,
-      "repeatPanelId": 8,
-      "scopedVars": {
-        "links": {
-          "selected": false,
-          "text": "AmLight: Miami to Santiago 100GE",
-          "value": "AmLight: Miami to Santiago 100GE"
-        }
-      },
-      "targets": [
-        {
-          "aggregate_all": false,
-          "aggregator": [
-            "average"
-          ],
-          "bucket": [],
-          "bucketAggs": [
-            {
-              "field": "start",
-              "id": "2",
-              "settings": {
-                "interval": "auto",
-                "min_doc_count": 0,
-                "trimEdges": 0
-              },
-              "type": "date_histogram"
-            }
-          ],
-          "combineAllBy": "nothing",
-          "condition": [],
-          "dateFormat": "",
-          "displayFormat": "series",
-          "drillDown": [],
-          "drillDownAlias": "",
-          "drillDownValue": [],
-          "dsType": "elasticsearch",
-          "func": [
-            {
-              "alias": "",
-              "bucket": "",
-              "expanded": false,
-              "method": "average",
-              "operation": "",
-              "percentile": "85",
-              "root": true,
-              "target": "input",
-              "template": "",
-              "title": "Aggregate",
-              "type": "Aggregate",
-              "wrapper": []
-            }
-          ],
-          "groupby_field": " ",
-          "inlineGroupOperator": [
-            [
-              "",
-              "and"
-            ]
-          ],
-          "metricValueAliasMappings": {},
-          "metricValueAliases": [
-            ""
-          ],
-          "metricValues_array": [
-            "$data_direction"
-          ],
-          "metric_array": [
-            "link_name"
-          ],
-          "metrics": [
-            {
-              "field": "select field",
-              "id": "1",
-              "type": "count"
-            }
-          ],
-          "orderby_field": "",
-          "outerGroupOperator": [
-            ""
-          ],
-          "percentileValue": [
-            ""
-          ],
-          "rawQuery": true,
-          "refId": "A",
-          "series": "interface",
-          "target": "get  link_name, aggregate(values.$data_direction, 3600, $statistics) between ($START,$END) from interface where  ( link_name = \"$links\" )",
-          "target_alias": "",
-          "templateVariableValue": [
-            ""
-          ],
-          "timeField": "start",
-          "type": "timeserie",
-          "whereClauseGroup": [
-            [
-              {
-                "left": "link_name",
-                "op": "=",
-                "right": "$links"
-              }
-            ]
-          ]
-        }
-      ],
-      "timeFrom": null,
-      "title": "$links ($data_direction)",
-      "type": "marcusolsson-hourly-heatmap-panel"
-    },
-    {
-      "datasource": "Netsage TSDS",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "calculation": "mean",
-            "colorPalette": "interpolateBlues",
-            "colorSpace": "rgb",
-            "groupBy": 60
-          },
-          "decimals": 1,
-          "unit": "bps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 10,
-        "w": 6,
-        "x": 6,
-        "y": 16
+        "y": 46
       },
       "id": 10,
       "links": [],
@@ -1135,7 +1002,8 @@
         "to": "0"
       },
       "repeat": null,
-      "repeatIteration": 1594323465027,
+      "repeatDirection": "v",
+      "repeatIteration": 1597844239736,
       "repeatPanelId": 8,
       "scopedVars": {
         "links": {
@@ -1251,7 +1119,8 @@
             "calculation": "mean",
             "colorPalette": "interpolateBlues",
             "colorSpace": "rgb",
-            "groupBy": 60
+            "groupBy": 60,
+            "invertPalette": false
           },
           "decimals": 1,
           "unit": "bps"
@@ -1260,9 +1129,9 @@
       },
       "gridPos": {
         "h": 10,
-        "w": 6,
-        "x": 12,
-        "y": 16
+        "w": 24,
+        "x": 0,
+        "y": 56
       },
       "id": 11,
       "links": [],
@@ -1272,7 +1141,8 @@
         "to": "0"
       },
       "repeat": null,
-      "repeatIteration": 1594323465027,
+      "repeatDirection": "v",
+      "repeatIteration": 1597844239736,
       "repeatPanelId": 8,
       "scopedVars": {
         "links": {
@@ -1388,7 +1258,8 @@
             "calculation": "mean",
             "colorPalette": "interpolateBlues",
             "colorSpace": "rgb",
-            "groupBy": 60
+            "groupBy": 60,
+            "invertPalette": false
           },
           "decimals": 1,
           "unit": "bps"
@@ -1397,9 +1268,9 @@
       },
       "gridPos": {
         "h": 10,
-        "w": 6,
-        "x": 18,
-        "y": 16
+        "w": 24,
+        "x": 0,
+        "y": 66
       },
       "id": 12,
       "links": [],
@@ -1409,7 +1280,8 @@
         "to": "0"
       },
       "repeat": null,
-      "repeatIteration": 1594323465027,
+      "repeatDirection": "v",
+      "repeatIteration": 1597844239736,
       "repeatPanelId": 8,
       "scopedVars": {
         "links": {
@@ -1525,7 +1397,8 @@
             "calculation": "mean",
             "colorPalette": "interpolateBlues",
             "colorSpace": "rgb",
-            "groupBy": 60
+            "groupBy": 60,
+            "invertPalette": false
           },
           "decimals": 1,
           "unit": "bps"
@@ -1534,11 +1407,11 @@
       },
       "gridPos": {
         "h": 10,
-        "w": 6,
+        "w": 24,
         "x": 0,
-        "y": 26
+        "y": 76
       },
-      "id": 17,
+      "id": 13,
       "links": [],
       "options": {
         "from": "0",
@@ -1546,13 +1419,14 @@
         "to": "0"
       },
       "repeat": null,
-      "repeatIteration": 1594323465027,
+      "repeatDirection": "v",
+      "repeatIteration": 1597844239736,
       "repeatPanelId": 8,
       "scopedVars": {
         "links": {
           "selected": false,
-          "text": "AmLight: Santiago to Panama 100GE",
-          "value": "AmLight: Santiago to Panama 100GE"
+          "text": "AmLight: Miami to Santiago 100GE",
+          "value": "AmLight: Miami to Santiago 100GE"
         }
       },
       "targets": [
@@ -1662,7 +1536,8 @@
             "calculation": "mean",
             "colorPalette": "interpolateBlues",
             "colorSpace": "rgb",
-            "groupBy": 60
+            "groupBy": 60,
+            "invertPalette": false
           },
           "decimals": 1,
           "unit": "bps"
@@ -1671,9 +1546,9 @@
       },
       "gridPos": {
         "h": 10,
-        "w": 6,
-        "x": 6,
-        "y": 26
+        "w": 24,
+        "x": 0,
+        "y": 86
       },
       "id": 14,
       "links": [],
@@ -1683,7 +1558,8 @@
         "to": "0"
       },
       "repeat": null,
-      "repeatIteration": 1594323465027,
+      "repeatDirection": "v",
+      "repeatIteration": 1597844239736,
       "repeatPanelId": 8,
       "scopedVars": {
         "links": {
@@ -1799,7 +1675,8 @@
             "calculation": "mean",
             "colorPalette": "interpolateBlues",
             "colorSpace": "rgb",
-            "groupBy": 60
+            "groupBy": 60,
+            "invertPalette": false
           },
           "decimals": 1,
           "unit": "bps"
@@ -1808,9 +1685,9 @@
       },
       "gridPos": {
         "h": 10,
-        "w": 6,
-        "x": 12,
-        "y": 26
+        "w": 24,
+        "x": 0,
+        "y": 96
       },
       "id": 15,
       "links": [],
@@ -1820,7 +1697,8 @@
         "to": "0"
       },
       "repeat": null,
-      "repeatIteration": 1594323465027,
+      "repeatDirection": "v",
+      "repeatIteration": 1597844239736,
       "repeatPanelId": 8,
       "scopedVars": {
         "links": {
@@ -1936,7 +1814,8 @@
             "calculation": "mean",
             "colorPalette": "interpolateBlues",
             "colorSpace": "rgb",
-            "groupBy": 60
+            "groupBy": 60,
+            "invertPalette": false
           },
           "decimals": 1,
           "unit": "bps"
@@ -1945,9 +1824,9 @@
       },
       "gridPos": {
         "h": 10,
-        "w": 6,
-        "x": 18,
-        "y": 26
+        "w": 24,
+        "x": 0,
+        "y": 106
       },
       "id": 16,
       "links": [],
@@ -1957,7 +1836,8 @@
         "to": "0"
       },
       "repeat": null,
-      "repeatIteration": 1594323465027,
+      "repeatDirection": "v",
+      "repeatIteration": 1597844239736,
       "repeatPanelId": 8,
       "scopedVars": {
         "links": {
@@ -2073,7 +1953,8 @@
             "calculation": "mean",
             "colorPalette": "interpolateBlues",
             "colorSpace": "rgb",
-            "groupBy": 60
+            "groupBy": 60,
+            "invertPalette": false
           },
           "decimals": 1,
           "unit": "bps"
@@ -2082,11 +1963,11 @@
       },
       "gridPos": {
         "h": 10,
-        "w": 6,
+        "w": 24,
         "x": 0,
-        "y": 36
+        "y": 116
       },
-      "id": 21,
+      "id": 17,
       "links": [],
       "options": {
         "from": "0",
@@ -2094,13 +1975,14 @@
         "to": "0"
       },
       "repeat": null,
-      "repeatIteration": 1594323465027,
+      "repeatDirection": "v",
+      "repeatIteration": 1597844239736,
       "repeatPanelId": 8,
       "scopedVars": {
         "links": {
           "selected": false,
-          "text": "PIREN: Mauna Lani to Sydney 100GE",
-          "value": "PIREN: Mauna Lani to Sydney 100GE"
+          "text": "AmLight: Santiago to Panama 100GE",
+          "value": "AmLight: Santiago to Panama 100GE"
         }
       },
       "targets": [
@@ -2210,7 +2092,8 @@
             "calculation": "mean",
             "colorPalette": "interpolateBlues",
             "colorSpace": "rgb",
-            "groupBy": 60
+            "groupBy": 60,
+            "invertPalette": false
           },
           "decimals": 1,
           "unit": "bps"
@@ -2219,9 +2102,9 @@
       },
       "gridPos": {
         "h": 10,
-        "w": 6,
-        "x": 6,
-        "y": 36
+        "w": 24,
+        "x": 0,
+        "y": 126
       },
       "id": 18,
       "links": [],
@@ -2231,7 +2114,8 @@
         "to": "0"
       },
       "repeat": null,
-      "repeatIteration": 1594323465027,
+      "repeatDirection": "v",
+      "repeatIteration": 1597844239736,
       "repeatPanelId": 8,
       "scopedVars": {
         "links": {
@@ -2347,7 +2231,8 @@
             "calculation": "mean",
             "colorPalette": "interpolateBlues",
             "colorSpace": "rgb",
-            "groupBy": 60
+            "groupBy": 60,
+            "invertPalette": false
           },
           "decimals": 1,
           "unit": "bps"
@@ -2356,9 +2241,9 @@
       },
       "gridPos": {
         "h": 10,
-        "w": 6,
-        "x": 12,
-        "y": 36
+        "w": 24,
+        "x": 0,
+        "y": 136
       },
       "id": 19,
       "links": [],
@@ -2368,7 +2253,8 @@
         "to": "0"
       },
       "repeat": null,
-      "repeatIteration": 1594323465027,
+      "repeatDirection": "v",
+      "repeatIteration": 1597844239736,
       "repeatPanelId": 8,
       "scopedVars": {
         "links": {
@@ -2484,7 +2370,8 @@
             "calculation": "mean",
             "colorPalette": "interpolateBlues",
             "colorSpace": "rgb",
-            "groupBy": 60
+            "groupBy": 60,
+            "invertPalette": false
           },
           "decimals": 1,
           "unit": "bps"
@@ -2493,9 +2380,9 @@
       },
       "gridPos": {
         "h": 10,
-        "w": 6,
-        "x": 18,
-        "y": 36
+        "w": 24,
+        "x": 0,
+        "y": 146
       },
       "id": 20,
       "links": [],
@@ -2505,7 +2392,8 @@
         "to": "0"
       },
       "repeat": null,
-      "repeatIteration": 1594323465027,
+      "repeatDirection": "v",
+      "repeatIteration": 1597844239736,
       "repeatPanelId": 8,
       "scopedVars": {
         "links": {
@@ -2621,7 +2509,8 @@
             "calculation": "mean",
             "colorPalette": "interpolateBlues",
             "colorSpace": "rgb",
-            "groupBy": 60
+            "groupBy": 60,
+            "invertPalette": false
           },
           "decimals": 1,
           "unit": "bps"
@@ -2630,11 +2519,11 @@
       },
       "gridPos": {
         "h": 10,
-        "w": 6,
+        "w": 24,
         "x": 0,
-        "y": 46
+        "y": 156
       },
-      "id": 25,
+      "id": 21,
       "links": [],
       "options": {
         "from": "0",
@@ -2642,13 +2531,14 @@
         "to": "0"
       },
       "repeat": null,
-      "repeatIteration": 1594323465027,
+      "repeatDirection": "v",
+      "repeatIteration": 1597844239736,
       "repeatPanelId": 8,
       "scopedVars": {
         "links": {
           "selected": false,
-          "text": "PIREN: Seattle to Oahu 100GE",
-          "value": "PIREN: Seattle to Oahu 100GE"
+          "text": "PIREN: Mauna Lani to Sydney 100GE",
+          "value": "PIREN: Mauna Lani to Sydney 100GE"
         }
       },
       "targets": [
@@ -2758,7 +2648,8 @@
             "calculation": "mean",
             "colorPalette": "interpolateBlues",
             "colorSpace": "rgb",
-            "groupBy": 60
+            "groupBy": 60,
+            "invertPalette": false
           },
           "decimals": 1,
           "unit": "bps"
@@ -2767,9 +2658,9 @@
       },
       "gridPos": {
         "h": 10,
-        "w": 6,
-        "x": 6,
-        "y": 46
+        "w": 24,
+        "x": 0,
+        "y": 166
       },
       "id": 22,
       "links": [],
@@ -2779,7 +2670,8 @@
         "to": "0"
       },
       "repeat": null,
-      "repeatIteration": 1594323465027,
+      "repeatDirection": "v",
+      "repeatIteration": 1597844239736,
       "repeatPanelId": 8,
       "scopedVars": {
         "links": {
@@ -2895,7 +2787,8 @@
             "calculation": "mean",
             "colorPalette": "interpolateBlues",
             "colorSpace": "rgb",
-            "groupBy": 60
+            "groupBy": 60,
+            "invertPalette": false
           },
           "decimals": 1,
           "unit": "bps"
@@ -2904,9 +2797,9 @@
       },
       "gridPos": {
         "h": 10,
-        "w": 6,
-        "x": 12,
-        "y": 46
+        "w": 24,
+        "x": 0,
+        "y": 176
       },
       "id": 23,
       "links": [],
@@ -2916,7 +2809,8 @@
         "to": "0"
       },
       "repeat": null,
-      "repeatIteration": 1594323465027,
+      "repeatDirection": "v",
+      "repeatIteration": 1597844239736,
       "repeatPanelId": 8,
       "scopedVars": {
         "links": {
@@ -3032,7 +2926,8 @@
             "calculation": "mean",
             "colorPalette": "interpolateBlues",
             "colorSpace": "rgb",
-            "groupBy": 60
+            "groupBy": 60,
+            "invertPalette": false
           },
           "decimals": 1,
           "unit": "bps"
@@ -3041,9 +2936,9 @@
       },
       "gridPos": {
         "h": 10,
-        "w": 6,
-        "x": 18,
-        "y": 46
+        "w": 24,
+        "x": 0,
+        "y": 186
       },
       "id": 24,
       "links": [],
@@ -3053,7 +2948,8 @@
         "to": "0"
       },
       "repeat": null,
-      "repeatIteration": 1594323465027,
+      "repeatDirection": "v",
+      "repeatIteration": 1597844239736,
       "repeatPanelId": 8,
       "scopedVars": {
         "links": {
@@ -3169,7 +3065,8 @@
             "calculation": "mean",
             "colorPalette": "interpolateBlues",
             "colorSpace": "rgb",
-            "groupBy": 60
+            "groupBy": 60,
+            "invertPalette": false
           },
           "decimals": 1,
           "unit": "bps"
@@ -3178,9 +3075,148 @@
       },
       "gridPos": {
         "h": 10,
-        "w": 6,
-        "x": 6,
-        "y": 56
+        "w": 24,
+        "x": 0,
+        "y": 196
+      },
+      "id": 25,
+      "links": [],
+      "options": {
+        "from": "0",
+        "showLegend": false,
+        "to": "0"
+      },
+      "repeat": null,
+      "repeatDirection": "v",
+      "repeatIteration": 1597844239736,
+      "repeatPanelId": 8,
+      "scopedVars": {
+        "links": {
+          "selected": false,
+          "text": "PIREN: Seattle to Oahu 100GE",
+          "value": "PIREN: Seattle to Oahu 100GE"
+        }
+      },
+      "targets": [
+        {
+          "aggregate_all": false,
+          "aggregator": [
+            "average"
+          ],
+          "bucket": [],
+          "bucketAggs": [
+            {
+              "field": "start",
+              "id": "2",
+              "settings": {
+                "interval": "auto",
+                "min_doc_count": 0,
+                "trimEdges": 0
+              },
+              "type": "date_histogram"
+            }
+          ],
+          "combineAllBy": "nothing",
+          "condition": [],
+          "dateFormat": "",
+          "displayFormat": "series",
+          "drillDown": [],
+          "drillDownAlias": "",
+          "drillDownValue": [],
+          "dsType": "elasticsearch",
+          "func": [
+            {
+              "alias": "",
+              "bucket": "",
+              "expanded": false,
+              "method": "average",
+              "operation": "",
+              "percentile": "85",
+              "root": true,
+              "target": "input",
+              "template": "",
+              "title": "Aggregate",
+              "type": "Aggregate",
+              "wrapper": []
+            }
+          ],
+          "groupby_field": " ",
+          "inlineGroupOperator": [
+            [
+              "",
+              "and"
+            ]
+          ],
+          "metricValueAliasMappings": {},
+          "metricValueAliases": [
+            ""
+          ],
+          "metricValues_array": [
+            "$data_direction"
+          ],
+          "metric_array": [
+            "link_name"
+          ],
+          "metrics": [
+            {
+              "field": "select field",
+              "id": "1",
+              "type": "count"
+            }
+          ],
+          "orderby_field": "",
+          "outerGroupOperator": [
+            ""
+          ],
+          "percentileValue": [
+            ""
+          ],
+          "rawQuery": true,
+          "refId": "A",
+          "series": "interface",
+          "target": "get  link_name, aggregate(values.$data_direction, 3600, $statistics) between ($START,$END) from interface where  ( link_name = \"$links\" )",
+          "target_alias": "",
+          "templateVariableValue": [
+            ""
+          ],
+          "timeField": "start",
+          "type": "timeserie",
+          "whereClauseGroup": [
+            [
+              {
+                "left": "link_name",
+                "op": "=",
+                "right": "$links"
+              }
+            ]
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "title": "$links ($data_direction)",
+      "type": "marcusolsson-hourly-heatmap-panel"
+    },
+    {
+      "datasource": "Netsage TSDS",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "calculation": "mean",
+            "colorPalette": "interpolateBlues",
+            "colorSpace": "rgb",
+            "groupBy": 60,
+            "invertPalette": false
+          },
+          "decimals": 1,
+          "unit": "bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 206
       },
       "id": 26,
       "links": [],
@@ -3190,7 +3226,8 @@
         "to": "0"
       },
       "repeat": null,
-      "repeatIteration": 1594323465027,
+      "repeatDirection": "v",
+      "repeatIteration": 1597844239736,
       "repeatPanelId": 8,
       "scopedVars": {
         "links": {
@@ -3306,7 +3343,8 @@
             "calculation": "mean",
             "colorPalette": "interpolateBlues",
             "colorSpace": "rgb",
-            "groupBy": 60
+            "groupBy": 60,
+            "invertPalette": false
           },
           "decimals": 1,
           "unit": "bps"
@@ -3315,9 +3353,9 @@
       },
       "gridPos": {
         "h": 10,
-        "w": 6,
-        "x": 12,
-        "y": 56
+        "w": 24,
+        "x": 0,
+        "y": 216
       },
       "id": 27,
       "links": [],
@@ -3327,7 +3365,8 @@
         "to": "0"
       },
       "repeat": null,
-      "repeatIteration": 1594323465027,
+      "repeatDirection": "v",
+      "repeatIteration": 1597844239736,
       "repeatPanelId": 8,
       "scopedVars": {
         "links": {
@@ -3448,7 +3487,7 @@
         "h": 2,
         "w": 24,
         "x": 0,
-        "y": 66
+        "y": 226
       },
       "id": 9,
       "links": [],

--- a/dashboards/General/individual-flows-per-country.json
+++ b/dashboards/General/individual-flows-per-country.json
@@ -16,7 +16,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1596735586411,
+  "iteration": 1597843367033,
   "links": [],
   "panels": [
     {
@@ -3243,14 +3243,6 @@
               {
                 "id": "unit",
                 "value": "decbytes"
-              },
-              {
-                "id": "custom.displayMode",
-                "value": "gradient-gauge"
-              },
-              {
-                "id": "custom.width",
-                "value": 440
               }
             ]
           },


### PR DESCRIPTION
Fixes two things:

- The Individual Flows by Country had a bar graph in the sensors table. This was not consistent with any of the other sensor tables, so made the column just text like the others.
- Bandwidth Patterns had the Exchange Point row collapsed. I simply expanded the panel in the GUI and clicked save...this actually leads to quite a bit of the JSON changing though hence the big diff on that file. I also tried just flipping collapsed from true to false directly but it does not actually draw the panels, so it looks like the large diff is necessary to have the panels ready to display and shift everything else down on the page. This is probably more information then you care about...but in case you are wondering about why such a large diff for such a small change there you have it.