### PR TITLE
Disabling map animation on projects dashboard by default

### DIFF
--- a/dashboards/General/flow-data-for-projects.json
+++ b/dashboards/General/flow-data-for-projects.json
@@ -15,11 +15,42 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1602795395497,
+  "iteration": 1605195368494,
   "links": [],
   "panels": [
     {
       "__netsage_template": "navigation",
+      "choices": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11
+      ],
+      "cycleview": true,
+      "dashboardselection": true,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "grafanafavorites": true,
+      "gridPos": {
+        "h": 3,
+        "w": 2,
+        "x": 0,
+        "y": 0
+      },
+      "hamburgerPath": "https://portal.netsage.global/hamburger-v4.gif",
+      "id": 1,
       "link_text": [
         "What is the current state of the network?",
         "What are the top sources/destinations of flows?",
@@ -54,37 +85,6 @@
         "/grafana/d/CJC1FFhmz/other-flow-stats",
         "/grafana/d/VuuXrnPWz/flow-analysis"
       ],
-      "choices": [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10,
-        11
-      ],
-      "cycleview": true,
-      "dashboardselection": true,
-      "datasource": null,
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
-      "grafanafavorites": true,
-      "gridPos": {
-        "h": 3,
-        "w": 2,
-        "x": 0,
-        "y": 0
-      },
-      "hamburgerPath": "https://portal.netsage.global/hamburger-v4.gif",
-      "id": 1,
       "links": [],
       "sharescreen": true,
       "sideLogoPath": "https://portal.netsage.global/netsage-header-logo.png",
@@ -1627,9 +1627,9 @@
         "#2CCB7A",
         "#6D5BDD"
       ],
-      "animationPlaying": true,
-      "link_text": [],
-      "link_url": [],
+      "animationPlaying": false,
+      "array_option_1": [],
+      "array_option_2": [],
       "array_option_3": [],
       "array_option_4": [],
       "center_lat": "15",
@@ -1674,6 +1674,8 @@
         "show": true
       },
       "light_map_url": "https://stamen-tiles-{s}.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}{r}.png",
+      "link_text": [],
+      "link_url": [],
       "links": [],
       "max_total": 0,
       "num_lines": "100",


### PR DESCRIPTION
Disables animation on the map for the projects dashboards. This is consistent with the behavior on the discipline dashboard. The only relevant line is `"animationPlaying": false`. The rest is the usual Grafana cruft and should be harmless. 