### PR TITLE
Fix issue where science discipline map was blank

### DIFF
--- a/dashboards/General/flows-by-science-discipline.json
+++ b/dashboards/General/flows-by-science-discipline.json
@@ -21,7 +21,7 @@
   "panels": [
     {
       "__netsage_template": "navigation",
-      "array_option_1": [
+      "link_text": [
         "What is the current state of the network?",
         "What are the top sources/destinations of flows?",
         "What is the aggregate flow data for data archives?",
@@ -69,7 +69,6 @@
       },
       "hamburgerPath": "https://portal.netsage.global/hamburger-v4.gif",
       "id": 1,
-      "link_text": [],
       "link_url": [
         "/grafana/d/000000003/bandwidth-dashboard",
         "/grafana/d/xk26IFhmk/flow-data",


### PR DESCRIPTION
See title. Somehow `link_text` got changed to `array_option_1` in JSON. Fixed that and things worked again.