### PR TITLE
1.8.0 lava - top talkers dash

### DIFF
--- a/dashboards/General/flow-data-for-projects.json
+++ b/dashboards/General/flow-data-for-projects.json
@@ -3047,32 +3047,6 @@
       {
         "allValue": null,
         "current": {
-          "selected": false,
-          "text": "CERN - European Organization for Nuclear Research",
-          "value": "CERN - European Organization for Nuclear Research"
-        },
-        "datasource": "netsage",
-        "definition": "{\"find\":\"terms\", \"field\":\"meta.src_organization\", \"query\":\"meta.scireg.src.project_names:$project_type\", \"size\": 10000000}",
-        "hide": 2,
-        "includeAll": false,
-        "label": "Organization",
-        "multi": false,
-        "name": "organization",
-        "options": [],
-        "query": "{\"find\":\"terms\", \"field\":\"meta.src_organization\", \"query\":\"meta.scireg.src.project_names:$project_type\", \"size\": 10000000}",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "tagValuesQuery": "",
-        "tags": [],
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-      },
-      {
-        "allValue": null,
-        "current": {
           "selected": true,
           "text": [
             "All"

--- a/docker/setup_dashboard.sh
+++ b/docker/setup_dashboard.sh
@@ -24,8 +24,8 @@ cd /app/plugins
 ## BEGIN PLUGIN INSTALL ##
 
 #Install carpetplot //using forked version until PR is accepted
-#grafana-cli plugins install marcusolsson-hourly-heatmap-panel
-grafana-cli --pluginUrl "https://github.com/katrinaturner/grafana-hourly-heatmap-panel/archive/nullColorPickerTest.zip" plugins install marcusolsson-hourly-heatmap-panel
+grafana-cli plugins install marcusolsson-hourly-heatmap-panel
+#grafana-cli --pluginUrl "https://github.com/katrinaturner/grafana-hourly-heatmap-panel/archive/nullColorPickerTest.zip" plugins install marcusolsson-hourly-heatmap-panel
 
 # Install polystat
 grafana-cli plugins install grafana-polystat-panel

--- a/docker/setup_dashboard.sh
+++ b/docker/setup_dashboard.sh
@@ -24,8 +24,8 @@ cd /app/plugins
 ## BEGIN PLUGIN INSTALL ##
 
 #Install carpetplot //using forked version until PR is accepted
-grafana-cli plugins install marcusolsson-hourly-heatmap-panel
-#grafana-cli --pluginUrl "https://github.com/katrinaturner/grafana-hourly-heatmap-panel/archive/nullColorPickerTest.zip" plugins install marcusolsson-hourly-heatmap-panel
+#grafana-cli plugins install marcusolsson-hourly-heatmap-panel
+grafana-cli --pluginUrl "https://github.com/katrinaturner/grafana-hourly-heatmap-panel/archive/nullColorPickerTest.zip" plugins install marcusolsson-hourly-heatmap-panel
 
 # Install polystat
 grafana-cli plugins install grafana-polystat-panel

--- a/docker/setup_dashboard.sh
+++ b/docker/setup_dashboard.sh
@@ -24,8 +24,8 @@ cd /app/plugins
 ## BEGIN PLUGIN INSTALL ##
 
 #Install carpetplot //using forked version until PR is accepted
-#grafana-cli plugins install marcusolsson-hourly-heatmap-panel
-grafana-cli --pluginUrl "https://github.com/netsage-project/grafana-hourly-heatmap-panel/archive/master.zip" plugins install marcusolsson-hourly-heatmap-panel
+grafana-cli plugins install marcusolsson-hourly-heatmap-panel
+#grafana-cli --pluginUrl "https://github.com/katrinaturner/grafana-hourly-heatmap-panel/archive/nullColorPickerTest.zip" plugins install marcusolsson-hourly-heatmap-panel
 
 # Install polystat
 grafana-cli plugins install grafana-polystat-panel


### PR DESCRIPTION
update queries to filter org variable like the other dashboards. ie selecting an org will display top talkers to and from that org.